### PR TITLE
修复出现两个编辑按钮的问题

### DIFF
--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -76,6 +76,7 @@ class MenuController extends AdminController
 
         $tree->disableCreateButton();
         $tree->disableQuickCreateButton();
+        $tree->disableEditButton();
 
         $tree->branch(function ($branch) {
             $payload = "<i class='fa {$branch['icon']}'></i>&nbsp;<strong>{$branch['title']}</strong>";

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -68,6 +68,7 @@ class PermissionController extends AdminController
         $tree = new Tree(new $model());
 
         $tree->disableCreateButton();
+        $tree->disableEditButton();
 
         $tree->branch(function ($branch) {
             $payload = "<div class='pull-left' style='min-width:310px'><b>{$branch['name']}</b>&nbsp;&nbsp;[<span class='text-primary'>{$branch['slug']}</span>]";


### PR DESCRIPTION
菜单模型树和权限模型树显示时出现两个编辑按钮，一个是跳转编辑，一个是弹窗编辑，看上去不是很舒服。
因为弹窗编辑比较方便，所以去掉了跳转编辑。