### PR TITLE
Allowing certain form fields to be rendered conditionally in a simple way

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -764,21 +764,25 @@ class Field implements Renderable
     /**
      * Set the field as readonly mode.
      *
+     * @param bool $condition
+     *
      * @return $this
      */
-    public function readOnly()
+    public function readOnly(bool $condition = true)
     {
-        return $this->attribute('readonly', true);
+        return $condition ? $this->attribute('readonly', true) : $this;
     }
 
     /**
      * Set field as disabled.
      *
+     * @param bool $condition
+     *
      * @return $this
      */
-    public function disable()
+    public function disable(bool $condition = true)
     {
-        return $this->attribute('disabled', true);
+        return $condition ? $this->attribute('disabled', true) : $this;
     }
 
     /**


### PR DESCRIPTION
首先，非常感谢作者倾心制作的高颜值后台系统！本人一直在使用着laravel-admin，自从发现这个衍生作品之后就更加爱不惜手了，使用这个作品为我的一些项目节省下不少时间，至少可以更加专心于功能的建设上而不用担心后台的美观问题。

回到正题上，这个简单的PR可以允许我们有条件地渲染表单里的readonly以及disable field，在某些业务场景下，我们需要基于条件来简单地选择是否启用disable或者readonly选项。

例如，当用户拥有“edit-post”权限的时候，字段的被禁用效果就不会在前端渲染。

一般写法：
```php
(bool) $canEdit = Admin::user()->can('edit-post');

if ($canEdit) {
    $form->text('title')->required()->rules('string|max:50');
    $form->text('content')->required()->rules('string|max:50');
} else {
    $form->text('title')->required()->rules('string|max:50')->disable();
    $form->text('content')->required()->rules('string|max:50')->disable();
}
```
PR用例： 
```php
(bool) $canEdit = Admin::user()->can('edit-post');

$form->text('title')->required()->rules('string|max:50')->disable(!$canEdit);
$form->text('content')->required()->rules('string|max:50')->disable(!$canEdit);
```
这个PR理论上不会影响原有的流程，不需要在现有的基础上做任何的增添修改，假设已经在使用readonly和disable这两个表单选项。两个表单选项依旧可以不传入布尔参数来正常使用，只不过传入false的话系统就不会在前端渲染字段readonly和disable的效果。

其实提交这个PR的初衷就是为了减 (为) 少 (了) 重 (偷) 复 (懒)，希望大家喜欢。

再次感谢作者！

