### PR TITLE
多用户认证

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -182,6 +182,12 @@ class AdminServiceProvider extends ServiceProvider
     protected function loadAdminAuthConfig()
     {
         config(Arr::dot(config('admin.auth', []), 'auth.'));
+        
+        foreach ((array) config('admin.multi_app') as $app => $enable) {
+            if ($enable) {
+                config(Arr::dot(config($app.'.auth', []), 'auth.'));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
对于多应用(多后台),以new-admin.php为例, 该配置文件里面的auth需要在这里设置一下