### PR TITLE
对建表迁移文件做了一些功能扩充

### DIFF
--- a/database/migrations/2016_01_04_173148_create_admin_tables.php
+++ b/database/migrations/2016_01_04_173148_create_admin_tables.php
@@ -6,17 +6,23 @@ use Illuminate\Database\Schema\Blueprint;
 class CreateAdminTables extends Migration
 {
     /**
+     * Modify once, the whole document is happy and safe.
+     * @var string
+     */
+    private $use_config = 'admin';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        $connection = config('admin.database.connection') ?: config('database.default');
+        $connection = config($this->use_config . '.database.connection') ?: config('database.default');
 
-        Schema::connection($connection)->create(config('admin.database.users_table'), function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('username', 190)->unique();
+        Schema::connection($connection)->create(config($this->use_config . '.database.users_table'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('username', 191)->unique();
             $table->string('password', 60);
             $table->string('name');
             $table->string('avatar')->nullable();
@@ -24,27 +30,27 @@ class CreateAdminTables extends Migration
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.roles_table'), function (Blueprint $table) {
-            $table->increments('id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.roles_table'), function (Blueprint $table) {
+            $table->bigIncrements('id');
             $table->string('name', 50);
             $table->string('slug', 50)->unique();
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.permissions_table'), function (Blueprint $table) {
-            $table->increments('id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.permissions_table'), function (Blueprint $table) {
+            $table->bigIncrements('id');
             $table->string('name', 50);
             $table->string('slug', 50)->unique();
             $table->string('http_method')->nullable();
             $table->text('http_path')->nullable();
             $table->integer('order')->default(0);
-            $table->integer('parent_id')->default(0);
+            $table->bigInteger('parent_id')->default(0);
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.menu_table'), function (Blueprint $table) {
-            $table->increments('id');
-            $table->integer('parent_id')->default(0);
+        Schema::connection($connection)->create(config($this->use_config . '.database.menu_table'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('parent_id')->default(0);
             $table->integer('order')->default(0);
             $table->string('title', 50);
             $table->string('icon', 50)->nullable();
@@ -53,37 +59,41 @@ class CreateAdminTables extends Migration
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.role_users_table'), function (Blueprint $table) {
-            $table->integer('role_id');
-            $table->integer('user_id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.role_users_table'), function (Blueprint $table) {
+            $table->bigInteger('role_id');
+            $table->bigInteger('user_id');
+            $table->string('user_type', 191)->nullable();//laravel polymorphic many to many for multi admin app
             $table->unique(['role_id', 'user_id']);
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.role_permissions_table'), function (Blueprint $table) {
-            $table->integer('role_id');
-            $table->integer('permission_id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.role_permissions_table'), function (Blueprint $table) {
+            $table->bigInteger('role_id');
+            $table->bigInteger('permission_id');
             $table->unique(['role_id', 'permission_id']);
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.role_menu_table'), function (Blueprint $table) {
-            $table->integer('role_id');
-            $table->integer('menu_id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.role_menu_table'), function (Blueprint $table) {
+            $table->bigInteger('role_id');
+            $table->bigInteger('menu_id');
+            $table->string('menu_type', 191)->nullable();//laravel polymorphic many to many for multi admin app
             $table->unique(['role_id', 'menu_id']);
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.permission_menu_table'), function (Blueprint $table) {
-            $table->integer('permission_id');
-            $table->integer('menu_id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.permission_menu_table'), function (Blueprint $table) {
+            $table->bigInteger('permission_id');
+            $table->bigInteger('menu_id');
+            $table->string('menu_type', 191)->nullable();//laravel polymorphic many to many for multi admin app
             $table->unique(['permission_id', 'menu_id']);
             $table->timestamps();
         });
 
-        Schema::connection($connection)->create(config('admin.database.operation_log_table'), function (Blueprint $table) {
-            $table->increments('id');
-            $table->integer('user_id');
+        Schema::connection($connection)->create(config($this->use_config . '.database.operation_log_table'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id');
+            $table->string('user_type', 191)->nullable();//laravel polymorphic many to many for multi admin app
             $table->string('path');
             $table->string('method', 10);
             $table->string('ip');
@@ -100,17 +110,17 @@ class CreateAdminTables extends Migration
      */
     public function down()
     {
-        $connection = config('admin.database.connection') ?: config('database.default');
+        $connection = config($this->use_config . '.database.connection') ?: config('database.default');
 
-        Schema::connection($connection)->dropIfExists(config('admin.database.users_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.roles_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.permissions_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.menu_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.user_permissions_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.role_users_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.role_permissions_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.role_menu_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.permission_menu_table'));
-        Schema::connection($connection)->dropIfExists(config('admin.database.operation_log_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.users_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.roles_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.permissions_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.menu_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.user_permissions_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.role_users_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.role_permissions_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.role_menu_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.permission_menu_table'));
+        Schema::connection($connection)->dropIfExists(config($this->use_config . '.database.operation_log_table'));
     }
 }


### PR DESCRIPTION
①. 建表所参照的config文件作为变量, 方便拷贝后修改;
②. 数据表的主键已经表之间互相关联的外键类型从短整型改为长整型, 这样能支持更长的主键, 且兼容历史数据;
③. 给部分中间表增加了一个备用字段(例如user_type, menu_type), 便于使用Laravel的[多态多对多关系]特性来支持多用户或者多菜单; 当然, 这个字段不设置的话, 按照框架目前的模型关联关系, 也并不会造成其他意外情况, 因为目前框架并未引用到这几个备用字段.
④. 一些字段的长度从190改为191, 以支持utf8-mb4.

以上建表迁移文件, 已通过以下两条语句测试.
A: php artisan admin:install
B: php artisan migrate:rollback

最期望的结果: 看能否通过Laravel ORM模型的多态关联实现多应用, 多用户认证登录), 这样至少可以共享中间表, 看有没有什么好的完整思路.
https://xueyuanjun.com/post/19975.html#bkmrk-%E5%A4%9A%E5%AF%B9%E5%A4%9A%EF%BC%88%E5%A4%9A%E6%80%81%EF%BC%89