### PR TITLE
rows无数据时会报错

### DIFF
--- a/src/小部件/Table.php
+++ b/src/小部件/Table.php
@@ -30,12 +30,12 @@ class Table extends Widget
      * Table constructor.
      *
      * @param array $headers
-     * @param array $rows
+     * @param mixed $rows
      * @param array $style
      */
     public function __construct($headers = [], $rows = [], $style = [])
     {
-        if ($headers && ! $rows) {
+        if ($headers && $rows === false) {
             $rows = $headers;
             $headers = [];
         }


### PR DESCRIPTION
原来的判断方法，当$rows = []时，通过判断使$rows = $headers会导致意想不到的效果。

rows数据可能来自数据库，控制不了有多少条记录。
如果有需要把rows和header替换，rows改成false好一点