### PR TITLE
update for json in show

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -425,7 +425,7 @@ HTML;
 
         return $this->as(function ($v) use (&$val, $name) {
             if ($val instanceof \Closure) {
-                $val = $val->call($this, $v, $this->$name);
+                $val = $val->call($this, $v, Arr::get($this, $name));
             }
 
             if (is_array($v)) {
@@ -451,7 +451,7 @@ HTML;
 
         return $this->as(function ($v) use (&$val, $name) {
             if ($val instanceof \Closure) {
-                $val = $val->call($this, $v, $this->$name);
+                $val = $val->call($this, $v, Arr::get($this, $name));
             }
 
             if (is_array($v)) {


### PR DESCRIPTION
在詳情頁處理json字段時，如果跟dot一起用樣式會跑到default

![image](https://user-images.githubusercontent.com/55920306/89099241-69f61b80-d420-11ea-9e32-2249e83cb7de.png)

```php
// application是個json字段 {"access": "no"}

$show->field('application.access', 'json')
->using([
    'no' => '無法授權',
    'yes' => '批准',
])
->dot([
    'no' => 'danger',
    'yes' => 'warning',
]);
```