### PR TITLE
登录表单里的username字段改为动态

### DIFF
--- a/resources/views/pages/login.blade.php
+++ b/resources/views/pages/login.blade.php
@@ -38,7 +38,7 @@
                         <input
                                 type="text"
                                 class="form-control {{ $errors->has('username') ? 'is-invalid' : '' }}"
-                                name="username"
+                                name="{{ $username }}"
                                 placeholder="{{ trans('admin.username') }}"
                                 value="{{ old('username') }}"
                                 required

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -39,7 +39,7 @@ class AuthController extends Controller
             return redirect($this->redirectPath());
         }
 
-        return $content->full()->body(view($this->view));
+        return $content->full()->body(view($this->view)->with('username', $this->username()));
     }
 
     /**


### PR DESCRIPTION
当用户在`AuthController`中更改`username`时，如：
```
protected function username()
{
    return 'email';
}
```
登录表单里的字段名称也会随之变化：
```
<input
    type="text"
    class="form-control {{ $errors->has('username') ? 'is-invalid' : '' }}"
    name="username"
    name="{{ $username }}"  <------- 从后台读取
    placeholder="{{ trans('admin.username') }}"
    value="{{ old('username') }}"
    required
```