### PR TITLE
Fix select2 和 TinyMCE 的一些问题

### DIFF
--- a/resources/views/form/select.blade.php
+++ b/resources/views/form/select.blade.php
@@ -12,6 +12,7 @@
         <input type="hidden" name="{{$name}}"/>
 
         <select class="form-control {{$class}}" style="width: 100%;" name="{{$name}}" {!! $attributes !!} >
+            <option value=""></option>
             @if($groups)
                 @foreach($groups as $group)
                     <optgroup label="{{ $group['label'] }}">
@@ -21,7 +22,6 @@
                     </optgroup>
                 @endforeach
              @else
-                <option value=""></option>
                 @foreach($options as $select => $option)
                     <option value="{{$select}}" {{ Dcat\Admin\Support\Helper::equal($select, old($column, $value)) ?'selected':'' }}>{{$option}}</option>
                 @endforeach

--- a/src/Form/Field/Editor.php
+++ b/src/Form/Field/Editor.php
@@ -163,7 +163,7 @@ class Editor extends Field
         return <<<JS
 function (editor) {
     editor.on('Change', function(e) {
-        var content = e.level.content;
+        var content = e.getContent();
         if (! content) {
             content = e.level.fragments;
             content = content.length && content.join('');


### PR DESCRIPTION
1. 修复 TinyMCE 插入 视频资源，提交时，会将占位图代码一并保存。通过使用TinyMCE 的 `getContent()` 函数，获取最终提交值，可得到正确的 HTML代码。

2. 修复select2 分组选项时，一定会带默认值的问题。 应该缺省为空