### PR TITLE
:bug: fix TinyMCE 插入视频，保存时，会将TinyMCE占位图代码保存下来

### DIFF
--- a/src/Form/Field/Editor.php
+++ b/src/Form/Field/Editor.php
@@ -163,7 +163,7 @@ class Editor extends Field
         return <<<JS
 function (editor) {
     editor.on('Change', function(e) {
-        var content = e.getContent();
+        var content = e.target.getContent();
         if (! content) {
             content = e.level.fragments;
             content = content.length && content.join('');


### PR DESCRIPTION
不好意思，这里选择错误，导致js报错了。