### PR TITLE
修复模型中存在 hasMany 关联属性时保存数据会报 “Undefined index: _remove_” 错误的问题

### DIFF
--- a/src/Repositories/EloquentRepository.php
+++ b/src/Repositories/EloquentRepository.php
@@ -778,7 +778,7 @@ class EloquentRepository extends Repository implements TreeRepository
 
                         $instance = $relation->findOrNew(Arr::get($related, $keyName));
 
-                        if ($related[Form::REMOVE_FLAG_NAME] == 1) {
+                        if (Arr::get($related, Form::REMOVE_FLAG_NAME) == 1) {
                             $instance->delete();
 
                             continue;


### PR DESCRIPTION
当两个 Model 的关联关系为 `hasMany` ，但是表单没有通过 `$form->hasMany` 组件提交时，保存数据时会出现报错 “Undefined index: _remove_”。

我的模型定义为：

```php
class Article extends Model
{
    public function pictures()
    {
        return $this->hasMay(Picture::class);
    }
}

class Picture  extends Model
{
    public function article()
    {
        return $this->belongsTo(Article::class);
    }
}
```

表单代码为：

```php
class ArticleController extends AdminController
{
    public function form()
    {
        return Form::make(new Article(['pictures']), function(Form $form) {
            $form->saving(function (Form $form) {
                $form->input('pictures, [
                    ['path' => 'xxx'], ['path' => 'xxx'],
                ]);
            });
            // 其他表单代码
        });
    }
}

这个 PR 中将直接访问数组下标的代码，修改成了 `Arr::get()` ，这样一来可以使用其中的 `array_key_exists` 方法检查数组是否真的有这个索引，从而不再导致以上报错。