### PR TITLE
处理select控件中空格代码"&nbsp;"被原封不动显示的问题

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -121,6 +121,7 @@ $(document).on('change', "{$this->getElementClassSelector()}", function () {
             data: $.map(data, function (d) {
                 d.id = d.$idField;
                 d.text = d.$textField;
+                d = d.replace(/&nbsp;/g,'-');
                 return d;
             })
         }).val(target.attr('data-value').split(',')).trigger('change');


### PR DESCRIPTION
1. 重现场景: 当select联动时, 若后加载出来的数据使用诸如Model::selectOptions()方法, 则其中的&nbsp;会明文显示在select中, 体验不好.
2. 解决方案: 将&nbsp;替换为短中划线.
3. 如果希望有更好的视觉展示效果, 可以合并我接下来提交的另一个PR.