### PR TITLE
解决树状结构的层级前缀呈现随层级深度指数增加的问题

### DIFF
--- a/src/Traits/ModelTree.php
+++ b/src/Traits/ModelTree.php
@@ -310,6 +310,7 @@ trait ModelTree
     protected function buildSelectOptions(array $nodes = [], $parentId = 0, $prefix = '')
     {
         $prefix = $prefix ?: str_repeat('&nbsp;', 6);
+        $this->tree_prefix = $this->tree_prefix ?? $prefix;
 
         $options = [];
 
@@ -321,9 +322,9 @@ trait ModelTree
         $parentColumn = $this->getParentColumn();
 
         foreach ($nodes as $node) {
-            $node[$titleColumn] = $prefix.'&nbsp;'.$node[$titleColumn];
+            $node[$titleColumn] = $prefix.' '.$node[$titleColumn];
             if ($node[$parentColumn] == $parentId) {
-                $children = $this->buildSelectOptions($nodes, $node[$this->getKeyName()], $prefix.$prefix);
+                $children = $this->buildSelectOptions($nodes, $node[$this->getKeyName()], $prefix . $this->tree_prefix);
 
                 $options[$node[$this->getKeyName()]] = $node[$titleColumn];
 


### PR DESCRIPTION
A. 出现问题的场景: select联动返回的是树状带层级的数据时, 期望的分层时这样的(假设prefix为6个空格):
第1层: 0个空格;
第2层: 6个空格;
第3层: 12个空格;
第4层: 18个空格;
第5层: 24个空格;
...
实际上是:
第1层: 0个空格;
第2层: 6个空格;
第3层: 12个空格;
第4层: 24个空格;
第5层: 48个空格;
会发现实际上后一层是前一层的2倍;

B: 解决方案: 本次代码提交中引入 $this->tree_prefix, 共计变更3行代码