### PR TITLE
解决 MultipleSelectTable 中 js 中接收数据类型问题

### DIFF
--- a/src/Grid/Filter/Presenter/MultipleSelectTable.php
+++ b/src/Grid/Filter/Presenter/MultipleSelectTable.php
@@ -33,6 +33,8 @@ class MultipleSelectTable extends SelectTable
 
     protected function addScript()
     {
+        $options = json_encode($this->options);
+
         Admin::script(
             <<<JS
 {$this->dialog->getScript()}
@@ -43,7 +45,7 @@ Dcat.grid.SelectTable({
     input: '#hidden-{$this->id}',
     multiple: true,
     max: {$this->max},
-    values: {$this->options},
+    values: {$options},
 });
 JS
         );


### PR DESCRIPTION
使用 MultipleSelectTable 时，报错 Array to string conversion，发现为 js 拼接时传入的数据类型问题。