### PR TITLE
一对一模型关联更新数据时报错

### DIFF
--- a/src/Repositories/EloquentRepository.php
+++ b/src/Repositories/EloquentRepository.php
@@ -737,9 +737,7 @@ class EloquentRepository extends Repository implements TreeRepository
                         $related->{$relation->getForeignKeyName()} = $model->{$localKey};
                     }
 
-                    foreach ($prepared[$name] as $column => $value) {
-                        $related->setAttribute($column, $value);
-                    }
+                    $related->setAttribute($name, $values);
 
                     $related->save();
                     break;


### PR DESCRIPTION
vendor\dcat\laravel-admin\src\Repositories\EloquentRepository.php

739 行报错“Invalid argument supplied for foreach()”