### PR TITLE
Unify formatLabel methods and fix error with dots replacing in translation

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -249,10 +249,10 @@ class Field implements Renderable
      */
     protected function formatLabel($arguments = [])
     {
-	if(isset($arguments[0])) {
-	    return $arguments[0];
-	}
-	
+        if(isset($arguments[0])) {
+            return $arguments[0];
+        }
+
         $column = is_array($this->column) ? current($this->column) : $this->column;
 
         $label = admin_trans_field($column);

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -249,11 +249,15 @@ class Field implements Renderable
      */
     protected function formatLabel($arguments = [])
     {
+	if(isset($arguments[0])) {
+	    return $arguments[0];
+	}
+	
         $column = is_array($this->column) ? current($this->column) : $this->column;
 
-        $label = isset($arguments[0]) ? $arguments[0] : admin_trans_field($column);
+        $label = admin_trans_field($column);
 
-        return str_replace(['.', '_'], ' ', $label);
+        return str_replace('_', ' ', $label);
     }
 
     /**

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -410,9 +410,11 @@ class Column
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: admin_trans_field($this->name);
+	if($label) return $label;
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = admin_trans_field($this->name);
+
+        return str_replace('_', ' ', $label);
     }
 
     /**

--- a/src/Grid/Column.php
+++ b/src/Grid/Column.php
@@ -410,7 +410,7 @@ class Column
      */
     protected function formatLabel($label)
     {
-	if($label) return $label;
+        if($label) return $label;
 
         $label = admin_trans_field($this->name);
 

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -141,7 +141,7 @@ abstract class AbstractFilter
      */
     protected function formatLabel($label)
     {
-	if($label) return $label;
+        if($label) return $label;
 
         $label = admin_trans_field($this->column);
 

--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -141,9 +141,11 @@ abstract class AbstractFilter
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: admin_trans_field($this->column);
+	if($label) return $label;
 
-        return str_replace(['.', '_'], ' ', $label);
+        $label = admin_trans_field($this->column);
+
+        return str_replace('_', ' ', $label);
     }
 
     /**

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -158,8 +158,8 @@ class Field implements Renderable
      */
     protected function formatLabel($label)
     {
-	if($label) return $label;
-	
+        if($label) return $label;
+
         $label = admin_trans_field($this->name);
 
         return str_replace('_', ' ', $label);

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -158,9 +158,11 @@ class Field implements Renderable
      */
     protected function formatLabel($label)
     {
-        $label = $label ?: admin_trans_field($this->name);
+	if($label) return $label;
+	
+        $label = admin_trans_field($this->name);
 
-        return str_replace(['.', '_'], ' ', $label);
+        return str_replace('_', ' ', $label);
     }
 
     /**


### PR DESCRIPTION
If there is a programmer provided label we should pass it through. If not we don't need to replace dots, because admin_trans_field uses admin_trans that already removes dots if there are no translations available (it uses text after the last dot).