### PR TITLE
Remove unused variable "custom" from DropdownActions class

### DIFF
--- a/src/Grid/Displayers/DropdownActions.php
+++ b/src/Grid/Displayers/DropdownActions.php
@@ -13,11 +13,6 @@ class DropdownActions extends Actions
     /**
      * @var array
      */
-    protected $custom = [];
-
-    /**
-     * @var array
-     */
     protected $default = [];
 
     /**


### PR DESCRIPTION
You have changed the code to use the "appends" variable from the parent "Actions" class instead of the "custom" variable, so we don't need it anymore.