### PR TITLE
Update embeds.blade.php

### DIFF
--- a/resources/views/form/embeds.blade.php
+++ b/resources/views/form/embeds.blade.php
@@ -1,10 +1,10 @@
-
+@if($label==false)
 <div class="row">
     <div class="{{$viewClass['label']}}"><h4 class="pull-right">{!! $label !!}</h4></div>
     <div class="{{$viewClass['field']}}"></div>
 </div>
-
 <hr style="margin-top: 0px;">
+@endif
 
 <div id="embed-{{$column}}" class="embed-{{$column}}">
 
@@ -20,4 +20,6 @@
     </div>
 </div>
 
+@if($label==false)
 <hr style="margin-top: 0px;">
+@endif


### PR DESCRIPTION
当 Label 设置为false或空时隐藏掉这一行，这个适用于 JSON字段更新时，不想让他显示 表头想和普通表单行融为一体，或者在tab里当只有一个embeds时，本身tab的表头就可以作为embeds表头使用，再让程序自动加个表头很突兀，即使设置成false不显示，但是行占用也还在。