### PR TITLE
Fix hasMany field in WidgetForm with default method declared

### DIFF
--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -286,6 +286,8 @@ class NestedForm extends WidgetForm
             $field->attribute(Field::BUILD_IGNORE, true);
 
             $this->form->builder()->pushField((clone $field)->display(false));
+        } elseif ($this->model()->toArray()) {
+            $field->attribute(Field::BUILD_IGNORE, true);
         }
 
         $field->setRelation([


### PR DESCRIPTION
I had Widget/Form with the **default** method declared. This method returned **_my_model_->toArray()**, so there was the **id** field in it. I added hasMany field to that form and in NestedForm of this field it rewrote **id** from parent form by method **fillFields** in Widget/Form, so data in the database was messed.

This way (using my pull request) if there is **default** method declared we skip **fillFields**. If you have a better idea to fix this issue, please reject the pull request :)