### PR TITLE
将关联的用户模型改成可配置

### DIFF
--- a/src/Models/OperationLog.php
+++ b/src/Models/OperationLog.php
@@ -47,6 +47,6 @@ class OperationLog extends Model
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(Administrator::class);
+        return $this->belongsTo(config('admin.database.users_model'));
     }
 }


### PR DESCRIPTION


原因：当用户表和角色权限表并非在1个数据库中，且用户表不是 `admin_users` 时，`OperationLog` 模型仍然关联的是原来的用户模型和表，而且不能改。

```php
return $this->belongsTo(config('admin.database.users_model'));
```