### PR TITLE
新增按钮自定义名称和链接

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -112,6 +112,13 @@ class Grid
     protected $keyName;
 
     /**
+     * Default create url.
+     *
+     * @var string
+     */
+    protected $createUrl;
+
+    /**
      * View for grid to render.
      *
      * @var string
@@ -479,12 +486,28 @@ class Grid
     }
 
     /**
+     * Set create url.
+     *
+     * @return string
+     */
+    public function setCreateUrl(string $url)
+    {
+        $this->createUrl = $url;
+
+        return $this;
+    }
+
+    /**
      * Get create url.
      *
      * @return string
      */
     public function getCreateUrl()
     {
+        if ($this->createUrl) {
+            return $this->createUrl;
+        }
+
         $queryString = '';
 
         if ($constraints = $this->model()->getConstraints()) {

--- a/src/Grid/Tools/CreateButton.php
+++ b/src/Grid/Tools/CreateButton.php
@@ -5,6 +5,7 @@ namespace Dcat\Admin\Grid\Tools;
 use Dcat\Admin\Form;
 use Dcat\Admin\Grid;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Arr;
 
 class CreateButton implements Renderable
 {
@@ -27,7 +28,7 @@ class CreateButton implements Renderable
             return;
         }
 
-        $new = trans('admin.new');
+        $new = Arr::get($this->grid->variables(), 'createName', trans('admin.new'));
         $url = $this->grid->getCreateUrl();
         $class = $this->grid->makeName('dialog-create');
 


### PR DESCRIPTION
新增按钮自定义名称和链接

例：
```php
$grid->setCreateUrl(route('admin.user.category.create', ['category' => $id]));

$grid->addVariables(['createName' => '新增用户']);
```