### PR TITLE
代码生成器添加注释与翻译互填功能

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -26,6 +26,7 @@ return [
         'nullable'          => 'nullable',
         'key'               => 'key',
         'translate_title'   => 'Translate Title',
+        'sync_translation_with_comment' => 'Sync translation and comment',
     ],
     'client' => [
         'delete_confirm'    => 'Are you sure to delete this item ?',

--- a/resources/lang/zh_CN/admin.php
+++ b/resources/lang/zh_CN/admin.php
@@ -26,6 +26,7 @@ return [
         'nullable'          => '允许空值',
         'key'               => '索引',
         'translate_title'   => '翻译标题',
+        'sync_translation_with_comment' => '同步翻译与注释',
     ],
     'client' => [
         'delete_confirm'    => '确认删除?',

--- a/resources/lang/zh_TW/admin.php
+++ b/resources/lang/zh_TW/admin.php
@@ -26,6 +26,7 @@ return [
         'nullable'          => '允許null',
         'key'               => '索引',
         'translate_title'   => '翻譯標題',
+        'sync_translation_with_comment' => '同步翻譯與註釋',
     ],
     'client' => [
         'delete_confirm'    => '確認刪除?',

--- a/resources/views/helpers/scaffold.blade.php
+++ b/resources/views/helpers/scaffold.blade.php
@@ -204,6 +204,7 @@
 
                 <div class='form-group'>
                     <button type="button" class="btn btn-sm btn-primary btn-outline text-capitalize" id="add-table-field"><i class="feather icon-plus"></i>&nbsp;&nbsp;{{(trans('admin.scaffold.add_field'))}}</button>
+                    <button type="button" class="btn btn-sm btn-primary btn-outline text-capitalize ml-1" id="sync-translation-with-comment"><i class="feather icon-repeat"></i>&nbsp;&nbsp;{{(trans('admin.scaffold.sync_translation_with_comment'))}}</button>
                 </div>
 
                 <div class="row">
@@ -332,6 +333,22 @@
 
         $('#add-table-field').click(function (event) {
             addField();
+        });
+
+        $('#sync-translation-with-comment').click(function (event) {
+            var element = $('#table-fields-sortable tr');
+            if (element.length > 0) {
+                element.each(function (i, v) {
+                    var translation = $(v).find('input[name="fields[' + i + '][translation]"]');
+                    var comment = $(v).find('input[name="fields[' + i + '][comment]"]');
+                    if (translation.val() !== "" && comment.val() === "") {
+                        comment.val(translation.val());
+                    }
+                    if (translation.val() === "" && comment.val() !== "") {
+                        translation.val(comment.val());
+                    }
+                });
+            }
         });
 
         $('#table-fields').on('click', '.table-field-remove', function(event) {


### PR DESCRIPTION
这个PR可以解决一部分重复劳动工作，添加字段的时候不用再一个一个的复制翻译输入框的内容粘贴到注释输入框里了。

现在你可以在翻译里先写好内容，然后点一下按钮，注释里的内容就自动填充好了，当然也可以反着来，或者注释和翻译各写一部分，然后点这个按钮就好了。