### PR TITLE
Allow to set parent_id in permission model using create method

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -21,7 +21,7 @@ class Permission extends Model implements Sortable
     /**
      * @var array
      */
-    protected $fillable = ['name', 'slug', 'http_method', 'http_path'];
+    protected $fillable = ['parent_id','name', 'slug', 'http_method', 'http_path'];
 
     /**
      * @var array

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -21,7 +21,7 @@ class Permission extends Model implements Sortable
     /**
      * @var array
      */
-    protected $fillable = ['parent_id','name', 'slug', 'http_method', 'http_path'];
+    protected $fillable = ['parent_id', 'name', 'slug', 'http_method', 'http_path'];
 
     /**
      * @var array


### PR DESCRIPTION
It should be possible to easily create tree permissions in migrations for example using the Permission::create method - now it's not.
"parent_id" is already in the Menu model $fillable array, so let's make it here too. 