### PR TITLE
解决 联动加载后，初始值丢失的问题

### DIFF
--- a/resources/views/filter/multipleselect.blade.php
+++ b/resources/views/filter/multipleselect.blade.php
@@ -3,7 +3,7 @@
         <span class="input-group-text bg-white text-capitalize"><b>{!! $label !!}</b></span>
     </div>
 
-    <select class="form-control {{ $class }}" name="{{$name}}[]" multiple style="width: 100%;">
+    <select class="form-control {{ $class }}" name="{{$name}}[]" multiple style="width: 100%;" data-value="{{implode(',',(array) $value)}}">
         @foreach($options as $select => $option)
             <option value="{{$select}}" {{ in_array((string)$select, (array) $value)  ?'selected':'' }}>{{$option}}</option>
         @endforeach


### PR DESCRIPTION
当使用联动时，父母级请求到联动数据后，将原选项清空并重新插入请求到的选项，在这一步中会丢失balde渲染的数据，而在resources/views/scripts/select.blade.php 中，已有通过属性data-value来二次赋值的逻辑，故利用之。

可能造成的影响：
1. 当再次回到父级的初始选项时，保存的数据不会被清空
2. 其它父级联动出的数据可能会产生脏数据
可选解决方案[TODO]：
在 resources/views/filter/multipleselect.blade.php 中增加属性data-init-parent作为初始父级的当前选项值，并在
在 resources/views/scripts/select.blade.php 中判断 this.value 的值是否与了级属性data-init-parent相等来决定是否加载data-value。
