### PR TITLE
解决执行迁移时报错的问题

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -292,6 +292,7 @@ return [
         'role_permissions_table' => 'admin_role_permissions',
         'role_menu_table'        => 'admin_role_menu',
         'permission_menu_table'  => 'admin_permission_menu',
+        'operation_log_table'    => 'admin_operation_log',
         'settings_table'         => 'admin_settings',
         'extensions_table'       => 'admin_extensions',
         'extension_histories_table' => 'admin_extension_histories',


### PR DESCRIPTION
嗨，我发现一个BUG。当我在执行`php artisan admin:install`后，会报错：
![image](https://user-images.githubusercontent.com/31812811/115098886-3125b480-9f65-11eb-9608-f0606c36ee94.png)
因为在执行迁移的时候，`operation_log_table`这个表名没有在`config/admin.php`中定义。现已修改。