### PR TITLE
Fix escaping of the upload button label

### DIFF
--- a/resources/views/form/file.blade.php
+++ b/resources/views/form/file.blade.php
@@ -68,7 +68,7 @@
             pick: {
                 id: $this.find('.file-picker'),
                 name: '_file_',
-                label: '<i class="feather icon-folder"></i>&nbsp; {!! trans('admin.uploader.add_new_media') !!}'
+                label: '<i class="feather icon-folder"><\/i>&nbsp; {!! trans('admin.uploader.add_new_media') !!}'
             },
             dnd: $this.find('.dnd-area'),
             paste: $this.find('.web-uploader')


### PR DESCRIPTION
Without this change the `"</i>"` is ignored, so "Browse" text is in the "i" tag and it is using feather font.