### PR TITLE
Fix: 多应用后台登录后跳转

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -43,6 +43,14 @@ class Application
     }
 
     /**
+     * 获取已经启用的 app 列表
+     */
+    public function enableApps()
+    {
+        return array_filter($this->apps);
+    }
+
+    /**
      * 设置当前应用配置.
      *
      * @param string $app

--- a/src/Http/Controllers/AuthController.php
+++ b/src/Http/Controllers/AuthController.php
@@ -3,6 +3,7 @@
 namespace Dcat\Admin\Http\Controllers;
 
 use Dcat\Admin\Admin;
+use Dcat\Admin\Application;
 use Dcat\Admin\Form;
 use Dcat\Admin\Http\Repositories\Administrator;
 use Dcat\Admin\Layout\Content;
@@ -241,10 +242,17 @@ class AuthController extends Controller
     {
         $request->session()->regenerate();
 
-        return $this->response()
+        $response = $this->response()
             ->success(trans('admin.login_successful'))
-            ->locationToIntended($this->getRedirectPath())
-            ->send();
+            ->locationToIntended($this->getRedirectPath());
+
+        // 如果当前启用了多应用后台,
+        // 不要跳去 session 存储的 path
+        if (! empty(Admin::app()->enableApps())) {
+            $response->location($this->getRedirectPath());
+        }
+
+        return $response->send();
     }
 
     /**


### PR DESCRIPTION
fixed: #398 

多后台登录:
admin1
admin2

如果先打开了 (同时打开多个后台登录页面)
admin1 跳转去登录页面 session.url.intended = admin1
然后打开
admin2 跳转去登录页面 session.url.intended = admin2

这时候回到 admin1 登录成功, 从 session 获取到上一个页面是 admin2
然后跳转到 admin2, 结果又跳转去 admin2 的登录页面(应该跳去 admin1 后台首页)