### PR TITLE
rename `boot()` method into `boot{TraitName}()`

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -136,10 +136,8 @@ trait HasPermissions
      *
      * @return void
      */
-    protected static function boot()
+    protected static function bootHasPermissions()
     {
-        parent::boot();
-
         static::deleting(function ($model) {
             $model->roles()->detach();
         });


### PR DESCRIPTION
Rename into this `boot{TraitName}()` style, can avoid `HasPermissions::boot()`'override by `config('admin.auth.providers.admin.model')::boot()`.


@see https://medium.com/swlh/laravel-booting-and-initializing-models-with-traits-2f77059b1915