### PR TITLE
Update RoleController.php

### DIFF
--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -97,6 +97,7 @@ class RoleController extends AdminController
             $form->text('name', trans('admin.name'))->required();
 
             $form->tree('permissions')
+                ->exceptParentNode(false)
                 ->nodes(function () {
                     $permissionModel = config('admin.database.permissions_model');
                     $permissionModel = new $permissionModel();

--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -97,7 +97,7 @@ class RoleController extends AdminController
             $form->text('name', trans('admin.name'))->required();
 
             $form->tree('permissions')
-                ->exceptParentNode(false)
+                ->tree(false)
                 ->nodes(function () {
                     $permissionModel = config('admin.database.permissions_model');
                     $permissionModel = new $permissionModel();


### PR DESCRIPTION
设置多级权限时，单选底层某一权限后，提交时会漏选父级ID，导致权限记录不全验证失败，关闭过滤父节点