### PR TITLE
Update RoleController.php

### DIFF
--- a/src/Http/Controllers/RoleController.php
+++ b/src/Http/Controllers/RoleController.php
@@ -97,6 +97,7 @@ class RoleController extends AdminController
             $form->text('name', trans('admin.name'))->required();
 
             $form->tree('permissions')
+                ->treeState(false)
                 ->nodes(function () {
                     $permissionModel = config('admin.database.permissions_model');
                     $permissionModel = new $permissionModel();


### PR DESCRIPTION
设置多级权限，单选任一权限后提交表单时父级ID漏选，导致权限记录不全，后续验证失败