### PR TITLE
Update Ajax.js

### DIFF
--- a/resources/assets/dcat/js/extensions/Ajax.js
+++ b/resources/assets/dcat/js/extensions/Ajax.js
@@ -92,6 +92,8 @@ export default class Ajax {
                     } catch (e) {}
                     return;
                 }
+             case 0:
+                return;
         }
 
         Dcat.error(_msg || (xhr.status + ' ' + msg));


### PR DESCRIPTION
修复select2搜索时，输入过快会报0 abort的错误