### PR TITLE
修复常用组件大小样式未生效的问题

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -226,6 +226,11 @@ class Field implements Renderable
     protected $savingCallbacks = [];
 
     /**
+     * @var string
+     */
+    protected $size = '';
+
+    /**
      * Field constructor.
      *
      * @param string|array $column
@@ -237,6 +242,22 @@ class Field implements Renderable
         $this->label = $this->formatLabel($arguments);
 
         $this->callResolving();
+    }
+
+    /**
+     * 设置为小尺寸.
+     */
+    public function small()
+    {
+        $this->size = 'sm';
+    }
+
+    /**
+     * 设置为大尺寸.
+     */
+    public function large()
+    {
+        $this->size = 'lg';
     }
 
     /**

--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -95,7 +95,8 @@ class Checkbox extends MultipleSelect
         $checkbox
             ->inline($this->inline)
             ->check($this->value())
-            ->class($this->getElementClassString());
+            ->class($this->getElementClassString())
+            ->size($this->size);
 
         $this->addVariables([
             'checkbox' => $checkbox,

--- a/src/Form/Field/Radio.php
+++ b/src/Form/Field/Radio.php
@@ -78,7 +78,8 @@ class Radio extends Field
         $radio
             ->inline($this->inline)
             ->check($this->value())
-            ->class($this->getElementClassString());
+            ->class($this->getElementClassString())
+            ->size($this->size);
 
         $this->addVariables([
             'radio' => $radio,

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -236,6 +236,11 @@ class Select extends Field
             'cascadeScript' => $this->getCascadeScript(),
         ]);
 
+        if ($this->size) {
+            $this->addElementClass('form-control-'.$this->size);
+            $this->setLabelClass('control-label-'.$this->size);
+        }
+
         $this->attribute('data-value', implode(',', Helper::array($this->value())));
 
         return parent::render();

--- a/src/Form/Field/Text.php
+++ b/src/Form/Field/Text.php
@@ -28,6 +28,11 @@ class Text extends Field
     {
         $this->initPlainInput();
 
+        if ($this->size) {
+            $this->addElementClass('form-control-'.$this->size);
+            $this->setLabelClass('control-label-'.$this->size);
+        }
+
         $this->defaultAttribute('type', 'text')
             ->defaultAttribute('name', $this->getElementName())
             ->defaultAttribute('value', $this->value())

--- a/src/Widgets/Radio.php
+++ b/src/Widgets/Radio.php
@@ -38,26 +38,6 @@ class Radio extends Widget
     }
 
     /**
-     * 设置为小尺寸.
-     *
-     * @return $this
-     */
-    public function small()
-    {
-        return $this->size('sm');
-    }
-
-    /**
-     * 设置为大尺寸.
-     *
-     * @return $this
-     */
-    public function large()
-    {
-        return $this->size('lg');
-    }
-
-    /**
      * 尺寸设置.
      *
      * "sm", "lg"


### PR DESCRIPTION
### 涉及组件
- input
- select
- checkbox
- radio

### 细节
- `input`、`select`组件中新增了相应的类名；
- `checkbox`、`radio`组件中修复了`$size`变量未生效的问题;
- `src/Widgets/Radio.php`中的`small()`方法和`large()`方法放到了`src/Form/Field.php`中，部分子类如`src/Form/Field/SwitchField.php`可以重写这两个方法；

### PS
- 目前`input`和`select`组件即使指定了大小也不生效，需要通过`Admin::css()`添加CSS代码覆盖原有样式。