### PR TITLE
feat: improve the display effect of web-uploader images

### DIFF
--- a/resources/assets/dcat/extra/upload.scss
+++ b/resources/assets/dcat/extra/upload.scss
@@ -301,7 +301,8 @@
 
 .web-uploader .filelist li img {
   max-width: 95%;
-  height: 120px
+  height: 120px;
+  object-fit: cover;
 }
 
 .web-uploader .filelist li p.error {

--- a/resources/assets/dcat/plugins/webuploader/webuploader.css
+++ b/resources/assets/dcat/plugins/webuploader/webuploader.css
@@ -303,7 +303,8 @@
 
 .web-uploader .filelist li img {
 	width: auto;
-	height: 120px
+	height: 120px;
+	object-fit: cover;
 }
 
 .web-uploader .filelist li p.error {

--- a/resources/dist/dcat/plugins/webuploader/webuploader.css
+++ b/resources/dist/dcat/plugins/webuploader/webuploader.css
@@ -303,7 +303,8 @@
 
 .web-uploader .filelist li img {
 	width: auto;
-	height: 120px
+	height: 120px;
+	object-fit: cover;
 }
 
 .web-uploader .filelist li p.error {


### PR DESCRIPTION
优化图片在 web-loader Form 组件中的展示效果。
目前图片预览存在超过预设宽高的图片拉伸变形的情况，该 pull request 通过在图片标签添加 object-fit = cover 的属性做到图片的覆盖效果，保证图片不变形。
<img width="294" alt="调整预览" src="https://user-images.githubusercontent.com/4065724/124764822-f16cd880-df67-11eb-9256-593ae210ad9d.png">
