### PR TITLE
在拓展菜单时使用多语言翻译出现类不存在的问题

### DIFF
--- a/src/Layout/Menu.php
+++ b/src/Layout/Menu.php
@@ -4,7 +4,7 @@ namespace Dcat\Admin\Layout;
 
 use Dcat\Admin\Admin;
 use Dcat\Admin\Support\Helper;
-use Lang;
+use Illuminate\Support\Facades\Lang;
 
 class Menu
 {


### PR DESCRIPTION
在拓展菜单时使用多语言翻译出现类不存在的问题，引入路径有误