### PR TITLE
:bug: 修复某些操作下出现空白筛选边栏的BUG

### DIFF
--- a/resources/assets/dcat/js/dcat-app.js
+++ b/resources/assets/dcat/js/dcat-app.js
@@ -95,6 +95,8 @@ function listen(Dcat) {
         new Footer(Dcat);
         // data-action 动作绑定(包括删除、批量删除等操作)
         new DataActions(Dcat);
+        // pjax初始化功能
+        new Pjax(Dcat);
     });
 
     // 每个请求都初始化
@@ -107,9 +109,6 @@ function listen(Dcat) {
                 'X-CSRF-TOKEN': Dcat.token
             }
         });
-
-        // pjax初始化功能
-        new Pjax(Dcat);
     });
 }
 


### PR DESCRIPTION
正好遇到和 #1406 同样的情况，经过仔细排查修复了这个BUG。

未修复前的情况是这样的：

![fail](https://user-images.githubusercontent.com/16308633/130063220-baad6f6a-ec36-4de9-a45d-c1842a0666bf.gif)

修复后是这样的：

![success](https://user-images.githubusercontent.com/16308633/130063280-e11ba2e9-2442-4e25-887b-b715e2228dc3.gif)

### 排查思路：

1、初步排查到[`src/Grid/Tools/FilterButton.php`](https://github.com/jqhph/dcat-admin/blob/10c480c996d2adbdde0266f1feb3625daeedaebb/src/Grid/Tools/FilterButton.php#L63-L76)文件中的`initSlider()`方法执行了多次，遂尝试修改执行该方法的条件，发现可以修复空白筛选边栏的BUG，但出现筛选按钮无法再次点击的BUG，说明不是这里的问题；

2、查看源代码之后发现了[`resources/assets/dcat/js/bootstrappers/Pjax.js`](https://github.com/jqhph/dcat-admin/blob/10c480c996d2adbdde0266f1feb3625daeedaebb/resources/assets/dcat/js/bootstrappers/Pjax.js#L9)文件中的`boot()`方法执行了多次，初步判断是pjax多次执行的问题；

3、随即排查pjax相关的代码，发现[`resources/assets/dcat/js/dcat-app.js`](https://github.com/jqhph/dcat-admin/blob/10c480c996d2adbdde0266f1feb3625daeedaebb/resources/assets/dcat/js/dcat-app.js#L101)中有相关注释，pjax确实执行了多次初始化，随后进行了修改，确认修复了BUG；
