### PR TITLE
:fire: 去掉针对无用配置项的判断条件

### DIFF
--- a/src/AdminServiceProvider.php
+++ b/src/AdminServiceProvider.php
@@ -133,7 +133,7 @@ class AdminServiceProvider extends ServiceProvider
      */
     protected function ensureHttps()
     {
-        if (config('admin.https') || config('admin.secure')) {
+        if (config('admin.https')) {
             \URL::forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);
         }

--- a/src/Layout/Asset.php
+++ b/src/Layout/Asset.php
@@ -502,7 +502,7 @@ class Asset
             $path = config('admin.assets_server').'/'.trim($path, '/');
         }
 
-        return (config('admin.https') || config('admin.secure')) ? secure_asset($path) : asset($path);
+        return config('admin.https') ? secure_asset($path) : asset($path);
     }
 
     /**

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -278,7 +278,7 @@ if (! function_exists('admin_url')) {
             return $path;
         }
 
-        $secure = $secure ?: (config('admin.https') || config('admin.secure'));
+        $secure = $secure ?: config('admin.https');
 
         return url(admin_base_path($path), $parameters, $secure);
     }


### PR DESCRIPTION
`config/admin.php`中并没有`secure`配置项，所以，也不需要针对它的判断条件。