### PR TITLE
🎈 perf(thumbnail): 访问缩略图时不检查图片是否存在

### DIFF
--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -2,7 +2,6 @@
 
 namespace Dcat\Admin\Traits;
 
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 trait Resizable
@@ -18,7 +17,7 @@ trait Resizable
     public function thumbnail($type, $attribute = 'image', $disk = null)
     {
         // Return empty string if the field not found
-        if (! isset($this->attributes[$attribute])) {
+        if (!isset($this->attributes[$attribute])) {
             return '';
         }
 
@@ -27,7 +26,7 @@ trait Resizable
 
         $thumbnail = $this->getThumbnailPath($image, $type);
 
-        return Storage::disk($disk ?: config('admin.upload.disk'))->exists($thumbnail) ? $thumbnail : null;
+        return $thumbnail;
     }
 
     /**
@@ -44,9 +43,9 @@ trait Resizable
         $ext = pathinfo($image, PATHINFO_EXTENSION);
 
         // We remove extension from file name so we can append thumbnail type
-        $name = Str::replaceLast('.'.$ext, '', $image);
+        $name = Str::replaceLast('.' . $ext, '', $image);
 
         // We merge original name + type + extension
-        return $name.'-'.$type.'.'.$ext;
+        return $name . '-' . $type . '.' . $ext;
     }
 }


### PR DESCRIPTION
exists 会发起网络请求

我使用的是 S3 存储图片，不适用缩略图时响应速度挺快的
使用缩略图后，基本每个页面都是 5 秒开外

其他的驱动应该也或多或少会影响一些，只是影响大小的区别

个人感觉这种操作不要内置，完全可以交给使用者来决定检测与否