### PR TITLE
fix select table model

### DIFF
--- a/src/Grid/Filter/Presenter/SelectTable.php
+++ b/src/Grid/Filter/Presenter/SelectTable.php
@@ -67,7 +67,7 @@ class SelectTable extends Presenter
                 return [];
             }
 
-            return $model::find($v)->pluck($text, $id);
+            return $model::query()->where($id, $v)->pluck($text, $id);
         });
     }
 


### PR DESCRIPTION
 如下调用方式导致输入框无内容或者错误的内容.

            $grid->filter(function (Grid\Filter $filter) {
                $filter->in('user_id')
                       ->multipleSelectTable(UserProfile::make(['user_id' => request('user_id')]))
                       ->model(UserProfileModel::class, 'user_id', 'mobile')
                ;
            });

sql查询语句是:
    select * from user_profile where id = xxxx
正确的sql语句应该是
    select * from user_profile where user_id = xxxx