### PR TITLE
fix SelectTable::model

### DIFF
--- a/src/Grid/Filter/Presenter/SelectTable.php
+++ b/src/Grid/Filter/Presenter/SelectTable.php
@@ -63,7 +63,7 @@ class SelectTable extends Presenter
                 return [];
             }
 
-            return $model::query()->where($id, $v)->pluck($text, $id);
+            return $model::query()->whereIn($id, $v)->pluck($text, $id);
         });
     }
 


### PR DESCRIPTION
多选表也会用到该方法, 导致多选无法显示数据