### PR TITLE
修复Form表单编辑时使用Checkbox的checked方法无效

### DIFF
--- a/src/Form/Field/Checkbox.php
+++ b/src/Form/Field/Checkbox.php
@@ -93,9 +93,10 @@ class Checkbox extends MultipleSelect
             $checkbox->disable();
         }
 
+        $checked = $this->value ?: $this->checked;
         $checkbox
             ->inline($this->inline)
-            ->check($this->value())
+            ->check($checked)
             ->class($this->getElementClassString())
             ->size($this->size);
 


### PR DESCRIPTION
#1479 

表单编辑中，使用 checkbox 的 checked 时，传入参数无效

$form->checkbox('field')->options([...])->checked([...]);
查看 Checkbox 源码
使用的是 $this->value() 并没有用到 $this->checked，故导致checked传参无效
```php
$checkbox
            ->inline($this->inline)
            ->check($this->value())
            ->class($this->getElementClassString())
            ->size($this->size);
```

修改如下：

```php
        $checked = $this->value ?: $this->checked;
        $checkbox
            ->inline($this->inline)
            ->check($checked)
            ->class($this->getElementClassString())
            ->size($this->size);
```