### PR TITLE
多字段Field的默认值问题，默认值在Dcat\Admin\Widgets\Form中失效的问题

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -552,7 +552,6 @@ class Field implements Renderable
 
             return $this->value;
         }
-        
         if (is_array($this->value) && count(array_unique($this->value)) == 1 && array_values(array_unique($this->value))[0] === null) {
             return array_merge($this->value, $this->default());
         }

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -552,6 +552,11 @@ class Field implements Renderable
 
             return $this->value;
         }
+        
+        // 这里是多字段数组时，就无法判断 value 为全 null 的情况(value为全null,则返回default,或者合并)
+        if(is_array($this->value) && count(array_unique($this->value)) == 1 && array_values(array_unique($this->value))[0] === null) {
+            return array_merge($this->value, $this->default());
+        }
 
         $this->value = value($value);
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -554,7 +554,7 @@ class Field implements Renderable
         }
         
         // 这里是多字段数组时，就无法判断 value 为全 null 的情况(value为全null,则返回default,或者合并)
-        if(is_array($this->value) && count(array_unique($this->value)) == 1 && array_values(array_unique($this->value))[0] === null) {
+        if (is_array($this->value) && count(array_unique($this->value)) == 1 && array_values(array_unique($this->value))[0] === null) {
             return array_merge($this->value, $this->default());
         }
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -553,7 +553,6 @@ class Field implements Renderable
             return $this->value;
         }
         
-        // 这里是多字段数组时，就无法判断 value 为全 null 的情况(value为全null,则返回default,或者合并)
         if (is_array($this->value) && count(array_unique($this->value)) == 1 && array_values(array_unique($this->value))[0] === null) {
             return array_merge($this->value, $this->default());
         }


### PR DESCRIPTION
这里是多字段数组时，就无法判断 value 为全 null 的情况(value为全null,则返回default()，或者合并
跟这个问题一样：https://github.com/jqhph/dcat-admin/pull/1495