### PR TITLE
修复数据表格筛选默认项不能设置为0

### DIFF
--- a/src/Grid/Filter/AbstractFilter.php
+++ b/src/Grid/Filter/AbstractFilter.php
@@ -460,7 +460,7 @@ abstract class AbstractFilter
      */
     public function default($default = null)
     {
-        if ($default) {
+        if (filled($default)) {
             $this->defaultValue = $default;
         }
 


### PR DESCRIPTION
修复数据表格筛选默认项不能设置为0