### PR TITLE
为 select 增加 depends 方法（当ajax模式才有效）

### DIFF
--- a/resources/views/form/select-script.blade.php
+++ b/resources/views/form/select-script.blade.php
@@ -6,6 +6,8 @@
 
     @yield('admin.select-ajax')
 
+    @yield('admin.select-depends')
+
     @if(isset($remoteOptions))
     $.ajax({!! admin_javascript_json($remoteOptions) !!}).done(function(data) {
         configs.data = data;

--- a/resources/views/scripts/select.blade.php
+++ b/resources/views/scripts/select.blade.php
@@ -63,10 +63,10 @@
     $(selector).trigger('change');
 </script>
 @endif
-
-@if(isset($depends) && isset($ajax))
 {{--depends联动--}}
-<script once>
+<script>
+@section('admin.select-depends')
+@if(isset($depends) && isset($ajax))
     var _this = $('{!! $selector !!}');
     var fields = {!! $depends['fields'] !!};
     var form = _this.closest('form');
@@ -96,11 +96,21 @@
         return params;
     }
 
-    var getSourceUrl = function(url, params){
+    var getSourceUrl = function(url, params) {
         return url + (url.match(/\?/)?'&':'?') + (new URLSearchParams(params)).toString();
     }
 
-    @if($depends['clear'])
+    var resetSelect2Configs = function(form, fields) {
+        var params = getFormFieldsVal(form, fields);
+        var configs = $.extend({}, _this.data('selectConfigs'));
+
+        configs.ajax = !params ? {} : $.extend(configs.ajax, { url: getSourceUrl("{{ $ajax['url'] }}", params) });
+
+        _this.select2(configs)
+    }
+
+    resetSelect2Configs(form, fields);
+
     $.map(fields, function (field) {
         var _selectors = [
             '[name="' + field + '"]',
@@ -109,22 +119,16 @@
         $.map(_selectors, function(_selector){
             form.off('change.depends', _selector)
                 .on('change.depends', _selector, function () {
+                    @if($depends['clear'])
                     _this.val(null).trigger('change');
-
-                    var params = getFormFieldsVal(form, fields);
-                    var configs = $.extend({}, _this.data('selectConfigs'));
-
-                    configs.ajax = !params ? {} : $.extend(configs.ajax, { url: getSourceUrl("{{ $ajax['url'] }}", params) });
-
-                    _this.select2(configs)
+                    @endif
+                    resetSelect2Configs(form, fields);
                 });
-
-            form.find(_selector).trigger('change.depends');
         })
     });
-    @endif
-</script>
 @endif
+@overwrite
+</script>
 
 <script once>
     // on first focus (bubbles up to document), open the menu

--- a/resources/views/scripts/select.blade.php
+++ b/resources/views/scripts/select.blade.php
@@ -118,6 +118,8 @@
 
                     _this.select2(configs)
                 });
+
+            form.find(_selector).trigger('change.depends');
         })
     });
     @endif

--- a/resources/views/scripts/select.blade.php
+++ b/resources/views/scripts/select.blade.php
@@ -1,6 +1,7 @@
 <script>
 @section('admin.select-ajax')
     @if(isset($ajax))
+        var _this = $('{{ $selector }}');
         configs = $.extend(configs, {
         ajax: {
             url: "{{ $ajax['url'] }}",
@@ -32,6 +33,10 @@
             return markup;
         }
     });
+    @if(isset($depends))
+    _this.data('selectConfigs', $.extend({}, configs));
+    delete configs.ajax;
+    @endif
     @endif
 @overwrite
 </script>
@@ -59,3 +64,78 @@
 </script>
 @endif
 
+@if(isset($depends) && isset($ajax))
+{{--depends联动--}}
+<script once>
+    var _this = $('{!! $selector !!}');
+    var fields = {!! $depends['fields'] !!};
+    var form = _this.closest('form');
+
+    var getFormFieldsVal = function(form, fields){
+        var formData = $(form).serializeArray();
+        var params = {};
+
+        for (var field of fields) {
+            for (var data of formData) {
+                if (!data.value.length) {
+                    continue;
+                }
+                if (data.name === field) {
+                    params[field] = data.value
+                }else if (data.name === field + '[]') {
+                    if(!Array.isArray(params[field])){
+                        params[field] = []
+                    }
+                    params[field].push(data.value);
+                }
+            }
+            if (!params.hasOwnProperty(field)){
+                return false;
+            }
+        }
+        return params;
+    }
+
+    var getSourceUrl = function(url, params){
+        return url + (url.match(/\?/)?'&':'?') + (new URLSearchParams(params)).toString();
+    }
+
+    @if($depends['clear'])
+    $.map(fields, function (field) {
+        var _selectors = [
+            '[name="' + field + '"]',
+            '[name="' + field + '[]"]'
+        ];
+        $.map(_selectors, function(_selector){
+            form.off('change.depends', _selector)
+                .on('change.depends', _selector, function () {
+                    _this.val(null).trigger('change');
+
+                    var params = getFormFieldsVal(form, fields);
+                    var configs = $.extend({}, _this.data('selectConfigs'));
+
+                    configs.ajax = !params ? {} : $.extend(configs.ajax, { url: getSourceUrl("{{ $ajax['url'] }}", params) });
+
+                    _this.select2(configs)
+                });
+        })
+    });
+    @endif
+</script>
+@endif
+
+<script once>
+    // on first focus (bubbles up to document), open the menu
+    $(document).off('focus', '.select2-selection.select2-selection--single')
+        .on('focus', '.select2-selection.select2-selection--single', function (e) {
+            $(this).closest(".select2-container").siblings('select:enabled').select2('open');
+        });
+
+    // steal focus during close - only capture once and stop propogation
+    $(document).off('select2:closing', 'select.select2')
+        .on('select2:closing', 'select.select2', function (e) {
+            $(e.target).data("select2").$selection.one('focus focusin', function (e) {
+                e.stopPropagation();
+            });
+        });
+</script>

--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -13,6 +13,7 @@ class Select extends Field
     use CanCascadeFields;
     use CanLoadFields;
     use Sizeable;
+    use HasDepends;
 
     protected $cascadeEvent = 'change';
 


### PR DESCRIPTION
### 例子：

```
$form->select('state_id')->ajax('/state/search', 'id', 'name')->depends(['country_id']);
```


### depends 方法和之前 load 方法对比：

### 优势：

- 使用简单，仅在原有配置好ajax的select field 上加入 ``` ->depends([field1, field2]) ```
- 可适用上级 field 不限于select，可以是check box, radio, select, input...
- 发送查询ajax请求时，会带上depends 的 field 的值，方便使用通用API。

### 劣势：

- 仅适用于ajax模式，每次输入停顿都会向服务器发起 ajax 查询请求。
