### PR TITLE
修正 layer open 的款式为2的关闭按钮无法看到的BUG

### DIFF
--- a/resources/assets/dcat/sass/components/_layer.scss
+++ b/resources/assets/dcat/sass/components/_layer.scss
@@ -26,11 +26,6 @@
   color: $font-color;
 }
 
-.layui-layer-ico {
-  background: transparent!important;
-  color: $font-color;
-}
-
 .layui-layer-setwin .layui-layer-max:before {
   font-family: "feather";
   content: "\e908";


### PR DESCRIPTION
layer.open 如果设置closeBtn 为2，会不可见。

删除此段代码即可。

PS: 如需不可见closeBtn，可设为 0