### PR TITLE
fix: 修复表单文件上传时，若已添加过文件则无法继续拖拽上传的 bug

### DIFF
--- a/resources/views/form/file.blade.php
+++ b/resources/views/form/file.blade.php
@@ -11,6 +11,14 @@
     .web-uploader .filelist li p.upload-progress span {
         background: @primary(-8);
     }
+
+    .web-uploader .dnd-area.webuploader-dnd-over {
+        border: 3px dashed #999 !important;
+    }
+    .web-uploader .dnd-area.webuploader-dnd-over .placeholder {
+        border: none;
+    }
+
 </style>
 
 <div class="{{$viewClass['form-group']}} {{ $class }}">
@@ -24,8 +32,8 @@
         <input name="{{ $name }}" class="file-input" type="hidden" {!! $attributes !!}/>
 
         <div class="web-uploader {{ $fileType }}">
-            <div class="queueList">
-                <div class="placeholder dnd-area">
+            <div class="queueList dnd-area">
+                <div class="placeholder">
                     <div class="file-picker"></div>
                     <p>{{trans('admin.uploader.drag_file')}}</p>
                 </div>


### PR DESCRIPTION
# 问题描述
在 from 表单中使用 multipleimage 功能时，无法多次拖拽、上传图片。

# 复现方法
连续多次拖拽图片到编辑框。

# 相关 issue
https://github.com/jqhph/dcat-admin/issues/1314

# 修复效果

## 修复前：拖拽图片页面无响应
![image](https://user-images.githubusercontent.com/10796377/139399308-ed5bcdc2-895f-4d56-aa98-f097834efb04.png)

## 修复后
![image](https://user-images.githubusercontent.com/10796377/139399324-a01275e0-4e37-4a49-8300-25f6c6157e01.png)


