### PR TITLE
修复MongoDB分页时 Expected "limit" option to have type "integer" but found…

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -535,7 +535,10 @@ class Model
             return;
         }
 
-        return $this->request->get($this->getPerPageName()) ?: $this->perPage;
+        $perPage =  $this->request->get($this->getPerPageName()) ?: $this->perPage;
+        
+        if ($perPage) return intval($perPage);
+        return null;
     }
 
     /**


### PR DESCRIPTION
使用 `jenssegers/mongodb` 时，Grid组件设置每页大小时报错
```
Expected "limit" option to have type "integer" but found "string"
```
需要强制把参数转为integer