### PR TITLE
修复MongoDB 分页perPage错误

### DIFF
--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -539,7 +539,7 @@ class Model
         if ($perPage) {
             return (int) $perPage;
         }
-        
+
         return null;
     }
 

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -535,7 +535,9 @@ class Model
             return;
         }
 
-        return $this->request->get($this->getPerPageName()) ?: $this->perPage;
+        $perPage =  $this->request->get($this->getPerPageName()) ?: $this->perPage;
+        if($perPage) return (int)$perPage;
+        return null;
     }
 
     /**

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -535,7 +535,7 @@ class Model
             return;
         }
 
-        $perPage =  $this->request->get($this->getPerPageName()) ?: $this->perPage;
+        $perPage = $this->request->get($this->getPerPageName()) ?: $this->perPage;
         if ($perPage) {
             return (int) $perPage;
         }

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -536,7 +536,7 @@ class Model
         }
 
         $perPage =  $this->request->get($this->getPerPageName()) ?: $this->perPage;
-        if($perPage){
+        if ($perPage) {
             return (int) $perPage;
         }
         

--- a/src/Grid/Model.php
+++ b/src/Grid/Model.php
@@ -536,7 +536,10 @@ class Model
         }
 
         $perPage =  $this->request->get($this->getPerPageName()) ?: $this->perPage;
-        if($perPage) return (int)$perPage;
+        if($perPage){
+            return (int) $perPage;
+        }
+        
         return null;
     }
 


### PR DESCRIPTION
使用 `jenssegers/mongodb` 时，Grid组件设置每页大小时报错
```
Expected "limit" option to have type "integer" but found "string"
```
需要强制把参数转为integer