### PR TITLE
解决多应用模式下代码生成器生成的文件存储位置错误的问题

### DIFF
--- a/resources/views/helpers/scaffold.blade.php
+++ b/resources/views/helpers/scaffold.blade.php
@@ -77,7 +77,7 @@
                     <span for="inputControllerName" class="col-sm-1 control-label text-capitalize">{{(trans('admin.scaffold.controller'))}}</span>
 
                     <div class="col-sm-4">
-                        <input type="text" name="controller_name" class="form-control text-capitalize" id="inputControllerName" placeholder="{{(trans('admin.scaffold.controller'))}}" value="{{ old('controller_name', "App\\Admin\\Controllers\\") }}">
+                        <input type="text" name="controller_name" class="form-control text-capitalize" id="inputControllerName" placeholder="{{(trans('admin.scaffold.controller'))}}" value="{{ old('controller_name', "App\\".$app."\\Controllers\\") }}">
                     </div>
                 </div>
 
@@ -86,7 +86,7 @@
                     <span for="inputRepositoryName" class="col-sm-1 control-label text-capitalize">{{(trans('admin.scaffold.repository'))}}</span>
 
                     <div class="col-sm-4">
-                        <input type="text" name="repository_name" class="form-control text-capitalize" id="inputRepositoryName" placeholder="{{(trans('admin.scaffold.repository'))}}" value="{{ old('repository_name', "App\\Admin\\Repositories\\") }}">
+                        <input type="text" name="repository_name" class="form-control text-capitalize" id="inputRepositoryName" placeholder="{{(trans('admin.scaffold.repository'))}}" value="{{ old('repository_name', "App\\".$app."\\Repositories\\") }}">
                     </div>
                 </div>
 
@@ -302,8 +302,8 @@
             $fieldsBody = $('#table-fields tbody'),
             tpl = $('#table-field-tpl').html(),
             modelNamespace = 'App\\Models\\',
-            repositoryNamespace = 'App\\Admin\\Repositories\\',
-            controllerNamespace = 'App\\Admin\\Controllers\\',
+            repositoryNamespace = 'App\\{{$app}}\\Repositories\\',
+            controllerNamespace = 'App\\{{$app}}\\Controllers\\',
             dataTypeMap = {!! json_encode($dataTypeMap) !!},
             helpers = Dcat.helpers;
 

--- a/src/Http/Controllers/ScaffoldController.php
+++ b/src/Http/Controllers/ScaffoldController.php
@@ -78,6 +78,7 @@ class ScaffoldController extends Controller
         $dbTypes = static::$dbTypes;
         $dataTypeMap = static::$dataTypeMap;
         $action = URL::current();
+        $app = ucfirst(mb_substr(request()->path(), 0, mb_stripos(request()->path(), '/')));
         $tables = collect($this->getDatabaseColumns())->map(function ($v) {
             return array_keys($v);
         })->toArray();
@@ -87,7 +88,7 @@ class ScaffoldController extends Controller
             ->description(' ')
             ->body(view(
                 'admin::helpers.scaffold',
-                compact('dbTypes', 'action', 'tables', 'dataTypeMap')
+                compact('dbTypes', 'action', 'tables', 'dataTypeMap', 'app')
             ));
     }
 


### PR DESCRIPTION
多应用模式下，代码生成器生成的控制器和Repositories文件依然在`app/admin/`目录下，其实完全可以根据当前URL自动判断对应的应用。