### PR TITLE
使自定义表单中的tab支持传递自定义id

### DIFF
--- a/src/Form/Concerns/HasTabs.php
+++ b/src/Form/Concerns/HasTabs.php
@@ -17,11 +17,13 @@ trait HasTabs
      *
      * @param  string  $title
      * @param  Closure  $content
+     * @param  bool  $active
+     * @param  string|null  $id
      * @return $this
      */
-    public function tab($title, Closure $content, $active = false)
+    public function tab($title, Closure $content, $active = false, ?string $id = null)
     {
-        $this->getTab()->append($title, $content, $active);
+        $this->getTab()->append($title, $content, $active, $id);
 
         return $this;
     }


### PR DESCRIPTION
```
    public function form(): void
    {
        $this->tab('小程序设置', function () {
            .......
        }, false, 'mini');
        $this->tab('微信支付', function ($item) {
            ......
        }, false, 'wechat-pay');
    }
```

避免保存tab刷新页面后，无法正确选中原选中的tab项。