### PR TITLE
当将富文本编辑器当做web代码编辑时会出现代码编译情况

### DIFF
--- a/resources/views/form/markdown.blade.php
+++ b/resources/views/form/markdown.blade.php
@@ -11,7 +11,7 @@
         @include('admin::form.error')
 
         <div class="{{$class}}" {!! $attributes !!}>
-            <textarea class="d-none" name="{{$name}}" placeholder="{{ $placeholder }}">{!! $value !!}</textarea>
+            <textarea class="d-none" name="{{$name}}" placeholder="{{ $placeholder }}">{{ $value }}</textarea>
         </div>
 
         @include('admin::form.help-block')


### PR DESCRIPTION
比如：<x-ad-selector typeId="constant" AAA="AbC" template="default" clientApp="simple"/>变成<x-ad-selector typeid="constant" aaa="abc" template="default" clientapp="simple"></x-ad-selector>
标签大写转换成小写，标签自动补全，链接地址被转换