### PR TITLE
fix(DialogForm.php): 弹窗表单重置按钮隐藏失败

### DIFF
--- a/src/Widgets/DialogForm.php
+++ b/src/Widgets/DialogForm.php
@@ -28,7 +28,7 @@ class DialogForm
         'query'          => null,
         'lang'           => null,
         'forceRefresh'   => false,
-        'reset'          => true,
+        'resetButton'    => true,
     ];
 
     /**
@@ -108,7 +108,7 @@ class DialogForm
      */
     public function resetButton(bool $value = true)
     {
-        $this->options['reset'] = $value;
+        $this->options['resetButton'] = $value;
 
         return $this;
     }
@@ -226,7 +226,7 @@ class DialogForm
             <<<JS
 (function () {
     var opts = {$opts};
-    
+
     opts.success = function (success, response) {
         {$this->handlers['success']}
     };
@@ -236,7 +236,7 @@ class DialogForm
     opts.saved = function (success, response) {
         {$this->handlers['saved']}
     };
-    
+
     Dcat.DialogForm(opts);
 })();
 JS


### PR DESCRIPTION
DialogForm.js中对于重置按钮的显示控制使用的是属性resetButton，但DialogForm.php中使用的reset，因此将DialogForm.php中的调整为resetButton,更符合这个属性的意义