### PR TITLE
fix(form.autocomplete): 当valueField对应值为数字时,js组件报错

### DIFF
--- a/resources/views/form/autocomplete.blade.php
+++ b/resources/views/form/autocomplete.blade.php
@@ -29,7 +29,7 @@
 
                     if (valueField) {
                         return $.map(data, function (dat) {
-                            return {value: Dcat.helpers.get(dat, valueField), data: dat};
+                            return {value: Dcat.helpers.get(dat, valueField) + '', data: dat};
                         });
                     }
 


### PR DESCRIPTION
在远程api模式下,数据转换中强制将valueField对应值转换为字符串