### PR TITLE
Make administrator model compatible to authorizable interface

### DIFF
--- a/src/Models/Administrator.php
+++ b/src/Models/Administrator.php
@@ -6,6 +6,7 @@ use Dcat\Admin\Traits\HasDateTimeFormatter;
 use Dcat\Admin\Traits\HasPermissions;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Storage;
@@ -16,7 +17,7 @@ use Illuminate\Support\Facades\URL;
  *
  * @property Role[] $roles
  */
-class Administrator extends Model implements AuthenticatableContract
+class Administrator extends Model implements AuthenticatableContract, Authorizable
 {
     use Authenticatable,
         HasPermissions,

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -32,9 +32,10 @@ trait HasPermissions
      * Check if user has permission.
      *
      * @param $ability
+     * @param  array|mixed  $arguments
      * @return bool
      */
-    public function can($ability): bool
+    public function can($ability, $paramters = []): bool
     {
         if (! $ability) {
             return false;


### PR DESCRIPTION
Some packages which uses the Spatie-Permissions like [Spati-Mailcoach ](https://github.com/spatie/Mailcoach) require a Administrator Model which is compatible with the Authorizable Interface.

You get this error then:
"Spatie\Permission\PermissionRegistrar::Spatie\Permission\{closure}(): Argument #1 ($user) must be of type Illuminate\Contracts\Auth\Access\Authorizable, Dcat\Admin\Models\Administrator given"

As a solution I need to copy the whole model and HasPermission Trait to make it compatible, because you cannot simply override the "can" method. This is a very ugly solution, because I need to track changes on the Administrator model and the HasPermission Trait on dcat-updates.

This PR makes the Administrator Model compatible with the Authorizable Interface. Very simple changes nothing with impact. Not sure if you want to add this PR, maybe its a nice to have if some Spatie-Admin-Tools (or others) are compatible without problems.