### PR TITLE
支持嵌套资源控制器 Nested Resources

### DIFF
--- a/src/Http/Controllers/HasNestedResource.php
+++ b/src/Http/Controllers/HasNestedResource.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Dcat\Admin\Http\Controllers;
+
+use Dcat\Admin\Layout\Content;
+
+trait HasNestedResource
+{
+    /**
+     * The id of the nested resource's child model.
+     *
+     * @var string|int
+     */
+    protected $nestedResourceId;
+
+    /**
+     * The parameter name for the nested resource's route.
+     *
+     * @var string
+     */
+    protected $routeParameterName;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function show($id, Content $content)
+    {
+        return parent::show($this->getNestedResourceId(), $content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function edit($id, Content $content)
+    {
+        return parent::edit($this->getNestedResourceId(), $content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($id)
+    {
+        return parent::update($this->getNestedResourceId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($id)
+    {
+        return parent::destroy($this->getNestedResourceId());
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNestedResourceId()
+    {
+        if ($this->nestedResourceId) {
+            return $this->nestedResourceId;
+        }
+
+        return $this->nestedResourceId = request($this->getRouteParameterName());
+    }
+
+    /**
+     * @param  string|int  $id
+     * @return void
+     */
+    public function setNestedResourceId($id)
+    {
+        $this->nestedResourceId = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRouteParameterName()
+    {
+        if ($this->routeParameterName) {
+            return $this->routeParameterName;
+        }
+
+        return $this->routeParameterName = last(request()->route()->parameterNames());
+    }
+
+    /**
+     * @param  string  $name
+     * @return void
+     */
+    public function setRouteParameterName($name)
+    {
+        $this->routeParameterName = (string) $name;
+    }
+}


### PR DESCRIPTION
当使用嵌套资源控制器时，默认行为总是获取父级模型的 ID。

[嵌套资源 Nested Resources](https://laravel.com/docs/9.x/controllers#restful-nested-resources)

⚠️ 暂不支持 [浅层嵌套 Shallow Nesting](https://laravel.com/docs/9.x/controllers#shallow-nesting)

```php
// 嵌套资源 Nested Resources
Route::resource('photos.comments', PhotoCommentController::class);
// 这将生成如下路由
/photos/{photo}/comments/{comment}
```

访问 `/photos/1/comments/2` 是会错误的展示 `id` 为 `1` 的 `comment`。

现在只需添加 `HasNestedResource` `trait` 到你的控制器，即可自动纠正此问题。

```php
<?php

namespace App\Admin\Controllers;

...

use Dcat\Admin\Http\Controllers\HasNestedResource;

class PhotoCommentController extends AdminController
{
    use HasNestedResource;

    ...
}
```

你还可以在构造函数中手动设置模型 ID

```php
    public function __construct()
    {
        // 自己定义 id 获取方式
        $id = 100;

        $this->setNestedResourceId($id);
    }
```

或者手动设置路由参数的名称

```php
    public function __construct()
    {
        // 自己定义路由参数的名称
        $name = 'test';

        $this->setRouteParameterName($name);
    }
```
