### PR TITLE
修复使用点语法的关联模型字段值无法导出的问题

### DIFF
--- a/src/Grid/Exporters/AbstractExporter.php
+++ b/src/Grid/Exporters/AbstractExporter.php
@@ -217,11 +217,12 @@ abstract class AbstractExporter implements ExporterInterface
     /**
      * 格式化待导出数据.
      *
-     * @param  array  $data
+     * @param  Collection  $data
      * @return array
      */
     protected function normalize(Collection $data)
     {
+        $data = $data->toArray();
         foreach ($data as &$row) {
             $row = Arr::dot($row);
 
@@ -254,7 +255,7 @@ abstract class AbstractExporter implements ExporterInterface
     }
 
     /**
-     * @param  array  $data
+     * @param  Collection  $data
      * @return array
      */
     protected function callBuilder(Collection &$data)


### PR DESCRIPTION
normalize函数的参数$data是个collection，必须先转为array，不然Arr::dot不会生效，会导致使用点语法的关联字段导出后全部是空值。另外修改了注释里的类型提示，跟形参真实的类型一致

```php
//city是关联模型，列表里使用了 $grid->column('city.name')。
$data = collect([['id'=>1,'name'=>'william','city'=>['name'=>'深圳']]]);
$this->normalize($data);
//修复前的输出，并没有按函数预期产生点语法的city.name，导出后city.name就是空的
[{"id":1,"name":"william","city":{"name":"\u6df1\u5733"}}]  
//修复后 输出，出现了city.name，导出正常
array (
  0 => 
  array (
    'id' => 1,
    'name' => 'william',
    'city.name' => '深圳',
  ),
)  
```