### PR TITLE
修复项目路径中含有Admin造成代码生成器无法正常解析命名空间的问题

### DIFF
--- a/src/Http/Controllers/ScaffoldController.php
+++ b/src/Http/Controllers/ScaffoldController.php
@@ -80,7 +80,7 @@ class ScaffoldController extends Controller
         $action = URL::current();
         $namespaceBase = 'App\\'.implode('\\', array_map(function ($name) {
             return Str::studly($name);
-        }, explode(DIRECTORY_SEPARATOR, ltrim(config('admin.directory'), app_path().DIRECTORY_SEPARATOR))));
+        }, explode(DIRECTORY_SEPARATOR, substr(config('admin.directory'), strlen(app_path().DIRECTORY_SEPARATOR)))));
         $tables = collect($this->getDatabaseColumns())->map(function ($v) {
             return array_keys($v);
         })->toArray();


### PR DESCRIPTION
如题，