### PR TITLE
feat: 增加eot_view函数用来替代边界定位符.

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\Request;
 use Illuminate\Support\MessageBag;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 
 if (! function_exists('admin_setting')) {
     /**
@@ -591,5 +592,26 @@ if (! function_exists('format_byte')) {
         }
 
         return round($value, $dec).$prefix_arr[$i];
+    }
+}
+
+if (! function_exists('eot_view')) {
+    /**
+     * Get the evaluated view contents for the given EOT view.
+     *
+     * @param  string|null  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
+     */
+    function eot_view($view = null, $data = [], $mergeData = [])
+    {
+        $factory = app(ViewFactory::class);
+        $factory->addExtension('js','blade');
+        if (func_num_args() === 0) {
+            return $factory;
+        }
+
+        return $factory->make($view, $data, $mergeData)->render();
     }
 }


### PR DESCRIPTION
在日常渲染工具栏模板时,经常会混用定界符<<<来混合js代码和html代码.如下:
```
        return <<<JS
    console.log("111111111111111")
JS;

        return <<<HTML
<button class="dddddddd">ccccc</button>
HTML;
    }
```
以上两种代码风格.破坏了laravel的代码风格.让原本清晰的代码逻辑变得混乱不堪.难以维护阅读,难以维护.
```
        $test = "22222222222";
        return eot_view('js.eot',compact('test'));
```
eot.js 模板文件.
```
   console.log("{{$test}}")
```