### PR TITLE
修复ltrim参数问题

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -428,7 +428,7 @@ if (! function_exists('admin_extension_path')) {
     {
         $dir = rtrim(config('admin.extension.dir'), '/') ?: base_path('dcat-admin-extensions');
 
-        $path = ltrim($path, '/');
+        $path = ltrim(path ?? '', '/');
 
         return $path ? $dir.'/'.$path : $dir;
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -428,7 +428,7 @@ if (! function_exists('admin_extension_path')) {
     {
         $dir = rtrim(config('admin.extension.dir'), '/') ?: base_path('dcat-admin-extensions');
 
-        $path = ltrim(path ?? '', '/');
+        $path = ltrim($path ?? '', '/');
 
         return $path ? $dir.'/'.$path : $dir;
     }


### PR DESCRIPTION
ltrim函数在php8.1里面第一个参数为`null`会警告