### PR TITLE
json表单hasmany方法支持子元素改变顺序

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -67,6 +67,8 @@ return [
     'create'                => 'Create',
     'delete'                => 'Delete',
     'remove'                => 'Remove',
+    'move_up'               => 'Move up',
+    'move_down'             => 'Move down',
     'edit'                  => 'Edit',
     'quick_edit'            => 'Quick Edit',
     'view'                  => 'View',

--- a/resources/lang/zh_CN/admin.php
+++ b/resources/lang/zh_CN/admin.php
@@ -63,6 +63,8 @@ return [
     'create'                => '创建',
     'delete'                => '删除',
     'remove'                => '移除',
+    'move_up'               => '上移',
+    'move_down'             => '下移',
     'edit'                  => '编辑',
     'quick_edit'            => '快捷编辑',
     'continue_editing'      => '继续编辑',

--- a/resources/lang/zh_TW/admin.php
+++ b/resources/lang/zh_TW/admin.php
@@ -63,6 +63,8 @@ return [
     'create'                => '創建',
     'delete'                => '刪除',
     'remove'                => '移除',
+    'move_up'               => '上移',
+    'move_down'             => '下移',
     'edit'                  => '編輯',
     'quick_edit'            => '快速編輯',
     'continue_editing'      => '繼續編輯',

--- a/resources/views/form/hasmany.blade.php
+++ b/resources/views/form/hasmany.blade.php
@@ -1,4 +1,15 @@
 
+<style>
+    .has-many-{{$columnClass}}-forms .has-many-{{$columnClass}}-form:last-child .{{$columnClass}}-down {
+        display: none;
+    }
+
+    .has-many-{{$columnClass}}-forms .has-many-{{$columnClass}}-form:first-child .{{$columnClass}}-up {
+        display: none;
+    }
+
+</style>
+
 <div class="row" style="margin-top: 10px;">
     <div class="{{$viewClass['label']}}"><h4 class="pull-right">{!! $label !!}</h4></div>
     <div class="{{$viewClass['field']}}"></div>
@@ -16,11 +27,17 @@
 
                 {!! $form->render() !!}
 
-                @if($options['allowDelete'])
+                @if($options['allowDelete'] || $options['allowMove'])
                     <div class="form-group row">
                         <label class="{{$viewClass['label']}} control-label"></label>
                         <div class="{{$viewClass['field']}}">
-                            <div class="{{$columnClass}}-remove btn btn-white btn-sm pull-right"><i class="feather icon-trash">&nbsp;</i>{{ trans('admin.remove') }}</div>
+                            @if($options['allowMove'])
+                                <div class="{{$columnClass}}-up btn btn-success btn-sm mr-1"><i class="fa fa-arrow-up">&nbsp;</i>{{ trans('admin.move_up') }}</div>
+                                <div class="{{$columnClass}}-down btn btn-info btn-sm"><i class="fa fa-arrow-down">&nbsp;</i>{{ trans('admin.move_down') }}</div>
+                            @endif
+                            @if($options['allowDelete'])
+                                <div class="{{$columnClass}}-remove btn btn-white btn-sm pull-right"><i class="feather icon-trash">&nbsp;</i>{{ trans('admin.remove') }}</div>
+                            @endif
                         </div>
                     </div>
                 @endif
@@ -36,12 +53,20 @@
 
             {!! $template !!}
 
-            <div class="form-group row">
-                <label class="{{$viewClass['label']}} control-label"></label>
-                <div class="{{$viewClass['field']}}">
-                    <div class="{{$columnClass}}-remove btn btn-white btn-sm pull-right"><i class="feather icon-trash"></i>&nbsp;{{ trans('admin.remove') }}</div>
+            @if($options['allowDelete'] || $options['allowMove'])
+                <div class="form-group row">
+                    <label class="{{$viewClass['label']}} control-label"></label>
+                    <div class="{{$viewClass['field']}}">
+                        @if($options['allowMove'])
+                            <div class="{{$columnClass}}-up btn btn-success btn-sm mr-1"><i class="fa fa-arrow-up"></i>&nbsp;{{ trans('admin.move_up') }}</div>
+                            <div class="{{$columnClass}}-down btn btn-info btn-sm"><i class="fa fa-arrow-down"></i>&nbsp;{{ trans('admin.move_down') }}</div>
+                        @endif
+                        @if($options['allowDelete'])
+                            <div class="{{$columnClass}}-remove btn btn-white btn-sm pull-right"><i class="feather icon-trash"></i>&nbsp;{{ trans('admin.remove') }}</div>
+                        @endif
+                    </div>
                 </div>
-            </div>
+            @endif
             <hr>
         </div>
     </template>
@@ -83,4 +108,30 @@
         $form.find('.{{ Dcat\Admin\Form\NestedForm::REMOVE_FLAG_CLASS }}').val(1);
         $form.find('[required]').prop('required', false);
     });
+
+    // move up
+    $(container).on('click', '.{{$columnClass}}-up', function () {
+        var $form = $(this).closest('.has-many-{{ $columnClass }}-form');
+        if ($form.prev().length === 0) {
+            return;
+        }
+
+        exchange($form.prev(), $form);
+    });
+
+    // move down
+    $(container).on('click', '.{{$columnClass}}-down', function () {
+        var $form = $(this).closest('.has-many-{{ $columnClass }}-form');
+        if ($form.next().length === 0) {
+            return;
+        }
+
+        exchange($form, $form.next());
+    });
+
+    var exchange = function (a, b) {
+        var n = a.next(), p = b.prev();
+        b.insertBefore(p);
+        a.insertAfter(n);
+    };
 </script>

--- a/src/Form/Field/HasMany.php
+++ b/src/Form/Field/HasMany.php
@@ -83,6 +83,7 @@ class HasMany extends Field
     protected $options = [
         'allowCreate' => true,
         'allowDelete' => true,
+        'allowMove'   => true,
     ];
 
     protected $columnClass;
@@ -533,6 +534,18 @@ class HasMany extends Field
     public function disableDelete()
     {
         $this->options['allowDelete'] = false;
+
+        return $this;
+    }
+
+    /**
+     * Disable move button.
+     *
+     * @return $this
+     */
+    public function disableMove()
+    {
+        $this->options['allowMove'] = false;
 
         return $this;
     }


### PR DESCRIPTION
支持如下方法：
```php
        $form->array('json', '内容', function ($table) {
            $table->text('title', '标题');
            $table->text('description', '描述');
        });
        
        $form->hasMany('json', '内容', function ($table) {
            $table->text('title', '标题');
            $table->text('description', '描述');
        });
```

默认启用上移和下移按钮

可以通过如下方法禁用：
```php
        $form->array('json', '内容', function ($table) {
            $table->text('title', '标题');
            $table->text('description', '描述');
        })->disableMove();
```