### PR TITLE
允许Modal强制使用a标签

### DIFF
--- a/src/Widgets/Modal.php
+++ b/src/Widgets/Modal.php
@@ -36,6 +36,11 @@ class Modal extends Widget
      * @var string|Closure|Renderable
      */
     protected $button;
+    
+    /**
+     * @var bool
+    */
+    protected $buttonWarp = false;
 
     /**
      * @var string
@@ -167,12 +172,13 @@ class Modal extends Widget
      * 设置按钮.
      *
      * @param  string|Closure|Renderable  $button
+     * @param  bool  $buttonWarp
      * @return $this
      */
-    public function button($button)
+    public function button($button, bool $buttonWarp = false)
     {
         $this->button = $button;
-
+        $this->buttonWarp = $buttonWarp;
         return $this;
     }
 
@@ -415,7 +421,7 @@ HTML;
         $button = Helper::render($this->button);
 
         // 如果没有HTML标签则添加一个 a 标签
-        if (! preg_match('/(\<\/[\d\w]+\s*\>+)/i', $button)) {
+        if (! preg_match('/(\<\/[\d\w]+\s*\>+)/i', $button) || $this->buttonWarp) {
             $button = "<a href=\"javascript:void(0)\">{$button}</a>";
         }
 


### PR DESCRIPTION
增加代码：允许强制使用a标签

原因：在使用[#表格批量操作弹窗](https://learnku.com/docs/dcat-admin/1.x/tools-form/8125#512b0f)时，为了跟主题的删除按钮一致（带图标），按原代码逻辑判断有html会不加a标签，导致样式不一致。

![1](https://user-images.githubusercontent.com/12254744/205101443-78493a6d-901d-484f-b9e3-5058e3cd4ff7.png)

![2](https://user-images.githubusercontent.com/12254744/205101387-0ebb45bc-f84f-4c22-9dae-f23e2ac85c82.png)