### PR TITLE
Use direct JS call instead of use $.initialize

### DIFF
--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -134,7 +134,7 @@ export default class Dcat {
 
                 callback.call(this, $this, id)
             };
-            $.each($(selector), (idx,elem) => fn.call(elem));
+            $(selector).each((idx,elem) => fn.call(elem));
             initialized[selector] = $.initialize(selector, fn, options);
         });
     }

--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -134,7 +134,7 @@ export default class Dcat {
 
                 callback.call(this, $this, id)
             };
-            $(selector).each((idx,elem) => fn.call(elem));
+            $(selector).each(fn);
             initialized[selector] = $.initialize(selector, fn, options);
         });
     }

--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -117,7 +117,7 @@ export default class Dcat {
         clear();
 
         setTimeout(function () {
-            initialized[selector] = $.initialize(selector, function () {
+            let fn = function () {
                 let $this = $(this),
                     id = $this.attr('id');
 
@@ -133,7 +133,9 @@ export default class Dcat {
                 }
 
                 callback.call(this, $this, id)
-            }, options);
+            };
+            $.each($(selector), (idx,elem) => fn.call(elem));
+            initialized[selector] = $.initialize(selector, fn, options);
         });
     }
 


### PR DESCRIPTION
We can call it directly on existing elements. It won't be called again because the initialized attribute is set. After it, it starts observing dom as it was...
In my code, I have a form with about 250 select fields. After this change page load was reduced **from about 2 minutes to 18 seconds.**