### PR TITLE
Dcat.init - scan only nodes for adds and updates, skip attributes changes

### DIFF
--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -116,7 +116,7 @@ export default class Dcat {
 
         clear();
 
-        options = $.extend(options, { target: $(this.config.pjax_container_selector).get(0) });
+        options = $.extend({ target: $(this.config.pjax_container_selector).get(0) }, options);
 
         setTimeout(function () {
             initialized[selector] = $.initialize(selector, function () {

--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -116,6 +116,8 @@ export default class Dcat {
 
         clear();
 
+        options = $.extend(options, { target: $(this.config.pjax_container_selector).get(0) });
+
         setTimeout(function () {
             initialized[selector] = $.initialize(selector, function () {
                 let $this = $(this),

--- a/resources/assets/dcat/js/Dcat.js
+++ b/resources/assets/dcat/js/Dcat.js
@@ -116,7 +116,7 @@ export default class Dcat {
 
         clear();
 
-        options = $.extend({ target: $(this.config.pjax_container_selector).get(0) }, options);
+        options = $.extend({ observer: { childList: true, subtree: true } }, options);
 
         setTimeout(function () {
             initialized[selector] = $.initialize(selector, function () {


### PR DESCRIPTION
Form elements selectors contain ids, classes, and names of elements, but we don't change any attributes used in selectors on the fly. 
In HasMany/array etc. we add a new node, so after my change, it is observed just fine, and the form elements callbacks are called.

Observing all attributes is really performance a pain in the neck.

In my code, I have a form with about 250 select fields. After this change page load time was **reduced from about 2 minutes to about 12 seconds.**

I haven't updated the "dist" code to make this pull request clean and simple!