### PR TITLE
Fix. $filter->expand(false) 在 panel 模式下不生效

### DIFF
--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -461,7 +461,7 @@ class Filter implements Renderable
 
         return tap(array_filter($conditions), function ($conditions) {
             if (! empty($conditions)) {
-                if ($this->expand === null || $this->mode !== static::MODE_RIGHT_SIDE) {
+                if ($this->expand === null) {
                     $this->expand();
                 }
 
@@ -536,7 +536,7 @@ class Filter implements Renderable
      */
     public function countConditions()
     {
-        return $this->mode() === Filter::MODE_RIGHT_SIDE
+        return !$this->expand
             ? count($this->getConditions()) : 0;
     }
 


### PR DESCRIPTION
1. 修复 $filter->expand(false) 在 panel 模式下不生效
2. 仅在 $filter->expand(false) 模式下显示当前选择的过滤参数个数