### PR TITLE
Fix: unable to see the quick search box on phone

### DIFF
--- a/resources/views/grid/quick-search.blade.php
+++ b/resources/views/grid/quick-search.blade.php
@@ -1,6 +1,6 @@
 <style>::-ms-clear,::-ms-reveal{display: none;}</style>
 
-<form pjax-container action="{!! $action !!}" class="input-no-border quick-search-form d-md-inline-block" style="display:none;margin-right: 16px">
+<form pjax-container action="{!! $action !!}" class="input-no-border quick-search-form d-block d-sm-inline-block" style="display:none;margin-right: 16px">
     <div class="table-filter">
         <label style="width: {{ $width }}rem">
             <input


### PR DESCRIPTION
the display for the form is none by default and d-md-inline-block only works when screen is middle size, as a result the quicksearch box is not visible on a small or extra small screen.