### PR TITLE
fix: 修复无法获取到语言翻译文件时，程序报错问题

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -542,7 +542,8 @@ class Admin
 
         $jsVariables['pjax_container_selector'] = $pjaxId ? ('#'.$pjaxId) : '';
         $jsVariables['token'] = csrf_token();
-        $jsVariables['lang'] = ($lang = __('admin.client')) ? array_merge($lang, $jsVariables['lang'] ?? []) : [];
+        $lang = (array) (__('admin.client') ?? []);
+        $jsVariables['lang'] = $lang ? array_merge($lang, $jsVariables['lang'] ?? []) : [];
         $jsVariables['colors'] = static::color()->all();
         $jsVariables['dark_mode'] = static::isDarkMode();
         $jsVariables['sidebar_dark'] = config('admin.layout.sidebar_dark') || ($sidebarStyle === 'dark');


### PR DESCRIPTION
当语言包目录的权限不对时，laravel 项目是无法正确进行翻译的。

无法获取到语言文件的原因是，相关目录权限不足。但这不应该成为项目产生报错的理由。权限不足时。__('admin.client') 获得的结果是 'admin.client'，是字符串，导致了此报错。


fixed #2037