### PR TITLE
fix:高德地图marker创建报错，无法显示问题

### DIFF
--- a/resources/views/form/map.blade.php
+++ b/resources/views/form/map.blade.php
@@ -210,13 +210,14 @@
     @endif
     @if($type === 'amap')
     function initAmap(){
+        var center = lng.val() && lat.val() ? [lng.val(), lat.val()] : null
         var map = new AMap.Map(container[0], {
             resizeEnable: true,
-            center: lng.val() && lat.val() ? [lng.val(), lat.val()] : null,
+            center: center,
             zoom: 14
         });
         var marker = new AMap.Marker({
-            position: new AMap.LngLat(lng.val(), lat.val()),
+            position: center,
             draggable: true,
             map:map,
             icon:'//a.amap.com/jsapi_demos/static/demo-center/icons/poi-marker-red.png',


### PR DESCRIPTION
修复高德地图marker初始化时没有经纬度，导致报错无法生成marker的问题