### PR TITLE
Update select.blade.php

### DIFF
--- a/resources/views/filter/select.blade.php
+++ b/resources/views/filter/select.blade.php
@@ -18,9 +18,11 @@
 
     @yield('admin.select-ajax')
 
+    {!! admin_section('admin.select-ajax'.$selector) !!}
+
     @if(isset($remote))
     $.ajax({!! admin_javascript_json($remote['ajaxOptions']) !!}).done(function(data) {
-        $("{{ $selector }}").select2($.extend({!! admin_javascript_json($configs) !!}, {
+        $("{{ $selector }}").select2($.extend(configs, {
             data: data,
         })).val({!! json_encode($remote['values']) !!}).trigger("change");
     });


### PR DESCRIPTION
添加钩子，使开发者能给指定的select控件进行个性化配置

例如：在grid方法中注入代码：
```php
admin_inject_section('admin.select-ajax.pk_project', "console.log(configs);configs = $.extend(configs, {escapeMarkup: function(e){return e}, templateSelection: function(t){return void 0!==t.description?t.text+'  <span class=\"text-gray\">'+t.description+'</span>':t.text}})");
```
在页面上能在实例化之前随意配置config变量：
```js
(function () {var configs = {"allowClear":true,"placeholder":{"id":"","text":"\u9009\u62e9"}};

        
    console.log(configs);configs = $.extend(configs, {escapeMarkup: function(e){return e}, templateSelection: function(t){return void 0!==t.description?t.text+'  <span class="text-gray">'+t.description+'':t.text}})

        $.ajax({"url":"http:\/\/127.0.0.1:8000\/admin\/fdc\/api\/project\/get_projects"}).done(function(data) {
        $(".pk_project").select2($.extend(configs, {
            data: data,
        })).val([]).trigger("change");
    });
})();;
```