### PR TITLE
Update HasPermissions.php

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -21,11 +21,14 @@ trait HasPermissions
             return $this->allPermissions;
         }
 
+        $permissionsModel = config('admin.database.permissions_model');
+        $primaryKey = (new $permissionsModel)->getKeyName();
+        
         return $this->allPermissions =
             $this->roles
             ->pluck('permissions')
             ->flatten()
-            ->keyBy($this->getKeyName());
+            ->keyBy($primaryKey);
     }
 
     /**


### PR DESCRIPTION
$this->getKeyName()是 admin_users表的主键,如果自定义登录后,主键名不为id时, 权限会出错. 这里直接取 admin_permissions 表的主键.