### PR TITLE
Show/Field Json() XSS脚本过滤

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -407,6 +407,14 @@ HTML;
         return $this->unescape()->as(function ($value) use ($field) {
             $content = is_string($value) ? json_decode($value, true) : $value;
 
+            if (is_array($content)) {
+                array_walk($content, function (&$v) {
+                    $v = htmlspecialchars($v);
+                });
+            } else {
+                $content = htmlspecialchars($content);
+            }
+
             $field->wrap(false);
 
             return Dump::make($content);


### PR DESCRIPTION
如果 Json 字段中存在 xss 执行脚本，会被直接渲染 html 执行。

复现：
`"[\"<sCRiPt sRC=\\/\\/code.jquery.com/jquery-3.7.1.min.js><\\/sCrIpT>\"]"`

由于是 <pre> 标签渲染，这里的 js 脚本直接被浏览器加载

<img width="339" alt="image" src="https://github.com/user-attachments/assets/12cf808f-d6c6-48b8-8b13-77e6cce434eb">

这里直接阻断了后续的 html 渲染

<img width="824" alt="image" src="https://github.com/user-attachments/assets/9e60fae2-f6aa-4727-ab8c-77ee39da4869">
