### PR TITLE
增加 Show json() 方法兼容性

### DIFF
--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -407,6 +407,14 @@ HTML;
         return $this->unescape()->as(function ($value) use ($field) {
             $content = is_string($value) ? json_decode($value, true) : $value;
 
+            if (is_array($content)) {
+                array_walk($content, function (&$v) {
+                    $v = htmlspecialchars($v);
+                });
+            } else {
+                $content = htmlspecialchars($content);
+            }
+
             $field->wrap(false);
 
             return Dump::make($content);

--- a/src/Show/Field.php
+++ b/src/Show/Field.php
@@ -409,6 +409,7 @@ HTML;
 
             if (is_array($content)) {
                 array_walk($content, function (&$v) {
+                    $v = strval($v);
                     $v = htmlspecialchars($v);
                 });
             } else {


### PR DESCRIPTION
当 $v 为 bool 时，htmlspecialchars() 会提示参数报错，先转换为 string，增加代码健壮性。