### PR TITLE
fix dcat-admin WYSIWYG editor html escape bug

### DIFF
--- a/resources/views/form/editor.blade.php
+++ b/resources/views/form/editor.blade.php
@@ -6,7 +6,7 @@
 
         @include('admin::form.error')
 
-        <textarea class="form-control {{$class}}" name="{{$name}}" placeholder="{{ $placeholder }}" {!! $attributes !!} >{{ $value }}</textarea>
+        <textarea class="form-control {{$class}}" name="{{$name}}" placeholder="{{ $placeholder }}" {!! $attributes !!} >{!! htmlentities($value) !!}</textarea>
 
         @include('admin::form.help-block')
 


### PR DESCRIPTION
Bug reproduce step:
1. Initialize a dcat-admin project and create an edit form contains a field using `->editor()` method.
2. Setup dcat-admin to use tinymce to render `->editor()`
3. Access admin dashboard edit page including wysiwyg, type something in wysiwyg field. And insert a snippet of HTML code, save the form.
4. Re-access the edit page, view the source code of entire wysiwyg field’s value.

You’re expected to see the html code was escaped. And this will lead you to lose code if save the form again. This is unexpected than what the user/editor’s intend. So I think it is definitely a bug.

