### PR TITLE
为 ModelCreator 增加模型的属性注解（只处理数据表已存在的场景）

### DIFF
--- a/src/Scaffold/ModelCreator.php
+++ b/src/Scaffold/ModelCreator.php
@@ -77,6 +77,7 @@ class ModelCreator
             ->replaceTable($stub, $this->name)
             ->replaceTimestamp($stub, $timestamps)
             ->replacePrimaryKey($stub, $keyName)
+            ->replaceComment($stub)
             ->replaceSpace($stub);
 
         $this->files->put($path, $stub);
@@ -242,6 +243,78 @@ class ModelCreator
     public function replaceSpace($stub)
     {
         return str_replace(["\n\n\n", "\n    \n"], ["\n\n", ''], $stub);
+    }
+    
+    /**
+     * replace comment.
+     * only for table exists.
+     * 可在 config/admin.php 中自定义列类型的映射规则 admin.database.column_type_mappings
+     *
+     * @param $stub
+     *
+     * @return $this
+     */
+    public function replaceComment(&$stub): ModelCreator
+    {
+        $types = [
+            'bit'       => 'int',
+            'tinyint'   => 'int',
+            'smallint'  => 'int',
+            'mediumint' => 'int',
+            'int'       => 'int',
+            'integer'   => 'int',
+            'bigint'    => 'int',
+    
+            'decimal' => 'float',
+            'numeric' => 'float',
+            'float'   => 'float',
+            'double'  => 'float',
+    
+            'date'      => 'string',
+            'time'      => 'string',
+            'datetime'  => '\Illuminate\Support\Carbon',
+            'timestamp' => '\Illuminate\Support\Carbon',
+            'year'      => 'string',
+    
+            'char'       => 'string',
+            'varchar'    => 'string',
+            'tinytext'   => 'string',
+            'text'       => 'string',
+            'mediumtext' => 'string',
+            'longtext'   => 'string',
+    
+            'binary'     => 'string',
+            'varbinary'  => 'string',
+            'tinyblob'   => 'string',
+            'blob'       => 'string',
+            'mediumblob' => 'string',
+            'longblob'   => 'string',
+    
+            'enum' => 'string',
+            'set'  => 'array',
+    
+            'json' => 'array',
+        ];
+        
+        // config/admin.php 自定义列类型的映射规则
+        $types = array_merge($types, config('admin.database.column_type_mappings', []));
+        
+        $cols  = Schema::getColumnListing($this->tableName);
+        
+        $comments = [];
+        foreach ($cols as $col) {
+            $type        = Schema::getColumnType($this->tableName, $col);
+            $typeComment = $types[$type] ?? 'string';
+            $comments[]  = " * @property $typeComment $col";
+        }
+        
+        $comment = implode(PHP_EOL, $comments);
+        $stub    = $comment
+            ? str_replace('DummyComment', $comment, $stub)
+            : str_replace(" *\nDummyComment\n", '', $stub);
+        $stub    = str_replace('DummyCreatedAt', Carbon::now()->toDateTimeString(), $stub);
+        
+        return $this;
     }
 
     /**

--- a/src/Scaffold/stubs/model.stub
+++ b/src/Scaffold/stubs/model.stub
@@ -6,6 +6,12 @@ DummyImportDateTimeFormatterTrait
 DummyImportSoftDeletesTrait
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * 创建时间 DummyCreatedAt
+ * @package DummyNamespace
+ *
+DummyComment
+ */
 class DummyClass extends Model
 {
 	DummyUseDateTimeFormatterTrait


### PR DESCRIPTION
1. 表不存在时根据模型迁移映射太麻烦，兼容但不处理，保持原样。
2. 表存在时会将各列自动添加到 @property {type} {name} 样式的注解。